### PR TITLE
Changes to basic format

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,10 @@
 Change log
 ==========
 
+**Version 0.8**
+
+* Updated charter to reflect the discussion at the Rutgers 7/11-9/1 2015 meeting.
+
 **Version 0.7**
 
 1. **Global nef name space**. All tags now start with '_nef_'.

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,19 @@ Change log
 
 * Updated charter to reflect the discussion at the Rutgers 7/11-9/1 2015 meeting.
 
+* Basic format rules
+	* Datablock name must now start with 'nef_'
+	* All sf_framecode must now start with the name of the corresponding
+		sf_category
+	* '?' is no longer supported to mean 'not set' - all unset parameters must
+		now be given as '.', which translates as null (None)
+	* mandatory and optional tags and key columns for loops defined and given in
+		Commented_Example.nef
+	* The convention of starting references to saveframes with a '$' is NOT 
+		supported any longer.
+	* added ordinal column to peak and restraint lists to provide unique
+		identifier for each line
+
 **Version 0.7**
 
 1. **Global nef name space**. All tags now start with '_nef_'.

--- a/Charter.md
+++ b/Charter.md
@@ -22,9 +22,9 @@ The organs of the consortium are the Assembly of members, the Executive Committe
 and Chairperson, the Secretariat, and the Specifications Repository.
 
 ## 2.1 Assembly
-The NEF project is governed by the Assembly of members, which is open to all
-groups that maintain software or services in a relevant scientific area, and
-that commit themselves to supporting the NEF format for data import and export.
+The NEF project is governed by the Assembly of members, which is open to anybody
+that is engaged in software or services in a relevant scientific area, and
+that commit themselves to supporting the NEF format.
 
 The Assembly meets at least once a year, possibly by audio or video conference, or in the
 form of an publicly accessible on-line discussion forum.

--- a/Charter.md
+++ b/Charter.md
@@ -2,19 +2,19 @@ NEF Consortium Charter
 ======================
 
 # 1 Preamble
-NEF denotes the Nmr Exchange Format. The purpose of the NEF consortium is to 
-establish, maintain, and distribute the NEF format for NMR data exchange 
+NEF denotes the Nmr Exchange Format. The purpose of the NEF consortium is to
+establish, maintain, and distribute the NEF format for NMR data exchange
 together with related specifications and utilities. The consortium is committed
 to provide the NEF format in a free and open form, and to support program-
-specific extensions. 
+specific extensions.
 
-The NEF consortium relies on consensus between the participants as the only 
+The NEF consortium relies on consensus between the participants as the only
 possible basis for a successful project.The charter therefore has only minimal
 provision for dealing with disputes.
 
 In order to be accepted by all participants, it is important that the NEF does
 not appear to be the 'property' of any single organisation. For this reason the
-charter allows for the division of tasks between multiple organisations. 
+charter allows for the division of tasks between multiple organisations.
 
 
 # 2 Consortium Organisation
@@ -22,66 +22,72 @@ The organs of the consortium are the Assembly of members, the Executive Committe
 and Chairperson, the Secretariat, and the Specifications Repository.
 
 ## 2.1 Assembly
-The NEF project is governed by the Assembly of members, which is open to all 
-groups that maintain software or services in a relevant scientific area, and 
+The NEF project is governed by the Assembly of members, which is open to all
+groups that maintain software or services in a relevant scientific area, and
 that commit themselves to supporting the NEF format for data import and export.
 
-The Assembly meets at least once a year, possibly by audio or video conference, or in the 
+The Assembly meets at least once a year, possibly by audio or video conference, or in the
 form of an publicly accessible on-line discussion forum.
-The meeting accepts the report of the Executive Committee, and selects the 
-Chairman and membership of the Executive Committee, the Secretariat, and the 
-Specifications Repository. All appointments are for one year periods only, to be formally 
-renewed annually. Assembly meetings must be called at least two weeks 
-in advance and made known to all registered members of the Assembly.
+The meeting accepts the report of the Executive Committee, and selects the
+membership of the Executive Committee, the Secretariat, and the
+Specifications Repository. All appointments are for one year periods,
+renewable indefinitely by subsequent Assmbly meetings. Assembly meetings must be
+called at least two weeks in advance and made known to all registered members of
+the Assembly.
+The agenda and decisions of Assembly meetings are public.
 
-Changes to the Consortium charter or to the membership are the sole prerogative 
+Changes to the Consortium charter or to the membership are the sole prerogative
 of the Assembly and cannot be delegated to the Executive Committee
 
-All decisions of the Assembly, including on the invitation or exclusion of 
-members, are taken by consensus. Where consensus cannot be obtained, decisions 
+All decisions of the Assembly, including on the invitation or exclusion of
+members, are taken by consensus. Where consensus cannot be obtained, decisions
 can be taken by a simple majority.
 
-## 2.1 Executive Committee
-Between meetings, the authority of the NEF is delegated to an Executive 
-Committee that acts on  behalf of the NEF consortium, consulting as necessary. 
-It is the task of the Executive Committee to guard, develop and promote the NEF standard 
+## 2.2 Executive Committee
+Between meetings, the authority of the NEF is delegated to an Executive
+Committee that acts on  behalf of the NEF consortium, consulting as necessary.
+It is the task of the Executive Committee to guard, develop and promote the NEF
+standard. The agenda and decisions of Executive Committee meetings are public.
 
-Decisions of the Executive Committee can be overruled by a general 
-Assembly meeting, or by an extraordinary assembly meeting called for the 
-purpose. Any member of the Executive Committee can call an extraordinary 
-Assembly meeting. 
+Decisions of the Executive Committee can be overruled by a general
+Assembly meeting, or by an extraordinary assembly meeting called for the
+purpose. Any member of the Executive Committee can call an extraordinary
+Assembly meeting.
 
-## 2.2 Executive Committee Chair
-The Executive Committee chair is selected by the Assembly meeting. He/She chairs 
-the Executive Committee and is responsible for calling Committee meetings,
-and for reporting to the Assembly.
+## 2.3 Executive Committee Chair
+The executive Committee selects its own Chairperson from among its members.
+He/She chairs the Executive Committee and is responsible for calling Committee
+meetings, and for reporting to the Assembly.
 
-## 2.3 Secretariat
-The Secratariat is responsible for maintaining the NEF web site and documentation,
-for keeping the Assembly membership list, for registering format change proposals,
-for maintaining the uniqueness of the tag prefixes 
+## 2.4 Secretariat
+The Secretariat is responsible for maintaining the NEF web site and
+documentation, for keeping the Assembly membership list, for registering format
+change proposals, for maintaining the uniqueness of the tag prefixes
 and for implementing the decisions of the Executive Committee.
 
 ## 2.4 Specifications Repository
-The Specifications Repository is responsible for maintaining the formal format 
+The Specifications Repository is responsible for maintaining the formal format
 specification, and for maintaining reference parsers and format validators.
 
 
 # 3 Changes to the NEF
-Changes and enhancements to the NEF can be proposed by all members of the assembly. 
-Changes and enhancements will be put forward in a structured fashion, comprised of a 
-time period for public discussion regarding the merit of the proposed change/enhancement, 
-a process of formal adaptation, and a agreed time period for implementation. Proper 
-versioning of the NEF will discriminate backward compatible minor changes
-from major, potentially incompatible changes.
+Changes and enhancements to the NEF can be proposed by all members of the
+assembly. Changes and enhancements will be put forward in a structured fashion,
+comprised of a time period for public discussion regarding the merit of the
+proposed change/enhancement, a process of formal adoption/rejection, and an
+agreed time period for implementation. Proper versioning of the NEF will
+discriminate backward compatible minor changes from major, potentially
+incompatible changes.
 
 
 # 4 Namespaces
-To assure that every developer can adopt the NEF standard, prefixes to the tags define 
-unique namespaces. Prefixes are directly associated with a program, program suite or the
-accepted NEF standard and can be used as seen fit, provided it adheres to the NEF syntax.
-The secretariat assures the uniqueness of the prefixes. Every developer can register a 
-prefix with the secretariat without the need for prior approval, provided the prefix is 
-unique. The Executive Committee can revoke an allocated prefix in case it is deemed 
-offensive, its usage inappropriate, creates confusion, or for other reasons that present 
-a detrimental effect to the integrity or implementation of the standard.
+To ensure that every developer can adopt the NEF standard, prefixes to the tags
+define unique namespaces. Prefixes are directly associated with a program,
+program suite or the accepted NEF standard and can be used as seen fit,
+provided it adheres to the NEF syntax. The secretariat assures the uniqueness
+of the prefixes. Every developer can register a prefix with the secretariat
+without the need for prior approval, provided the prefix is unique. The
+Executive Committee can revoke an allocated prefix in case it is deemed
+offensive, its usage inappropriate, creates confusion, or for other reasons
+that present a detrimental effect to the integrity or implementation of the
+standard.

--- a/specification/Commented_Example.nef
+++ b/specification/Commented_Example.nef
@@ -9,7 +9,7 @@
 #  The style is nmr-star.
 #
 
-data_my_nmr_project_1
+data_nef_my_nmr_project_1
 
 #
 #===========================================================================
@@ -29,20 +29,23 @@ save_nef_nmr_meta_data
   _nef_nmr_meta_data.sf_framecode           	nef_nmr_meta_data
 
   _nef_nmr_meta_data.format_name                  Nmr_Exchange_Format
-  _nef_nmr_meta_data.format_version               0.7
-  _nef_nmr_meta_data.program_name                 Cyana
-  _nef_nmr_meta_data.program_version              3.1
+  _nef_nmr_meta_data.format_version               0.8
+  _nef_nmr_meta_data.program_name                 CYANA
+  _nef_nmr_meta_data.program_version              3.01
   _nef_nmr_meta_data.creation_date                2013-02-29T13:12:03
 
 # Optional:
-  _nef_nmr_meta_data.coordinate_file_name         ?
+  _nef_nmr_meta_data.coordinate_file_name         depositiondir/somefile.ext
 
 # Optional loops (to end of saveframe):
 
 # Related database entries
   loop_
+    # mandatory parameters
   _nef_related_entries.database_name
   _nef_related_entries.database_accession_code
+
+  # key: database_name, database_accession_code
 
     BMRB   12345
     BMRB   22277
@@ -53,12 +56,19 @@ save_nef_nmr_meta_data
 
 # Program scripts used
   loop_
+    # mandatory parameter
     _nef_program_script.program_name
+    
+    # optional parameters
     _nef_program_script.script_name
     _nef_program_script.script
+    
+    # program,-specific parameter
     _nef_program_script.cyana_parameter_1
 
-    	Cyana  init.cya
+  # key: program_name, script_name
+
+    	CYANA  init.cya
 ;
 rmsdrange:=1-93
 
@@ -80,17 +90,20 @@ read seq protein.seq
    	12
   stop_
 
-# NOTE: cyana_parameter_1 is an example of a program-specific attribute.
-
 
 
 # Data history loop
   loop_
+    # mandatory parameters
     _nef_run_history.run_ordinal
     _nef_run_history.program_name
+    
+    # optional parameters
     _nef_run_history.program_version
     _nef_run_history.script_name
     _nef_run_history.script
+
+  # key: run_ordinal
 
     1   TOPSPIN  3.1   mypulprog.name
 ;
@@ -98,7 +111,7 @@ INSERT PULSE PROGRAM HERE
 
 ;
 
-    2   UNIO  ? ? ?
+    2   UNIO  . . .
   stop_
 
 # NOTE: The values in this loop refer to previous runs, and so contain
@@ -167,7 +180,7 @@ save_nef_molecular_system
     B	17	CYS	CYS_LFZW_DHG	single	disulfide
     C    1      ATP     .         	single	.
  # Manual comment: Pseudo-residues (tensor origin) added. 
-    C 900   TENSOR   .      .       .    
+    C 900   TNSR     .      .       .    
   stop_
 
 # Chain A is a linear dodecapeptide (15-25), disulfide linked to a single
@@ -194,6 +207,8 @@ save_nef_molecular_system
     _nef_covalent_links.residue_type_2
     _nef_covalent_links.atom_name_2
 
+  # key: chain_code_1, sequence_code_1, atom_name_1, chain_code_2, sequence_code_2, atom_name_2
+
     A 20 CYS SD B 17 CYS SD
     A 22 THR OG1 A 26 GLC C1
   stop_
@@ -208,13 +223,12 @@ save_
 # Mandatory: Chemical shift table(s)
 #===========================================================================
 
-save_chemical_shift_list_1
+save_nef_chemical_shift_list_1
 
-# All tags in this saveframe are mandatory
-# (shift uncertainty can be given as '?' if unknown).
+# All tags in this saveframe are mandatory, except for value_uncertainty.
 
   _nef_chemical_shift_list.sf_category           	nef_chemical_shift_list
-  _nef_chemical_shift_list.sf_framecode          	chemical_shift_list_1
+  _nef_chemical_shift_list.sf_framecode          	nef_chemical_shift_list_1
 
   _nef_chemical_shift_list.atom_chem_shift_units      ppm
 
@@ -225,6 +239,8 @@ save_chemical_shift_list_1
       _nef_chemical_shift.atom_name
       _nef_chemical_shift.value
       _nef_chemical_shift.value_uncertainty
+      
+  # key: chain_code, sequence_code, atom_name
 
       A	15	GLY	QA	 3.42	0.02
       A 17      VAL     HG#      0.73   0.02
@@ -273,17 +289,18 @@ save_
 #=======================================================================
 
 
-save_distance_restraint_list_L1
+save_nef_distance_restraint_list_L1
 
 
 # Mandatory parameters
   _nef_distance_restraint_list.sf_category          nef_distance_restraint_list
-  _nef_distance_restraint_list.sf_framecode         distance_restraint_list_L1
+  _nef_distance_restraint_list.sf_framecode         nef_distance_restraint_list_L1
 
   _nef_distance_restraint_list.potential_type       square-well-parabolic
 
   loop_
-  # Mandatory parameters
+    # Mandatory parameters, except for restraint_combination_id
+    _nef_distance_restraint.ordinal
     _nef_distance_restraint.restraint_id
     _nef_distance_restraint.restraint_combination_id
     _nef_distance_restraint.chain_code_1
@@ -296,31 +313,34 @@ save_distance_restraint_list_L1
     _nef_distance_restraint.atom_name_2
     _nef_distance_restraint.weight
 
-  # The following two parameters are mandatory.
-  # If they are not defined for a given potential they can be given a value of '?'
+  # The following parameters are optional. target_value and target_value_uncertainty
+  # should be given whenever a meaningful value is known'
+  # Other parameters need be given only if they are defined for the potential_type
     _nef_distance_restraint.target_value
     _nef_distance_restraint.target_value_uncertainty
-
-  # Optional parameters - use only the ones needed for the potential:
+    _nef_distance_restraint.lower_linear_limit
     _nef_distance_restraint.lower_limit
     _nef_distance_restraint.upper_limit
-  # _nef_distance_restraint.lower_linear_limit
-  # _nef_distance_restraint.upper_linear_limit
+    _nef_distance_restraint.upper_linear_limit
 
-    1  .   A 21  ALA  HB#  A 17  VAL  H   1.00 3.7  ?  2.5  4.2
-    1  .   A 21  ALA  HB#  A 18  LEU  H   1.00 3.7  ?  2.5  4.2
-    1  .   A 22  THR  HG2# A 17  VAL  H   1.00 3.7  ?  2.5  4.2
-    1  .   A 22  THR  HG2# A 18  LEU  H   1.00 3.7  ?  2.5  4.2
-    5  .   A 18  PHE  HB2  A 24  ASP  HBX 1.00 2.8  ?  2.0  3.2
-    8  .   A 18  PHE  HB2  A 24  ASP  HBY 1.00 4.4  ?  4.1  5.2
+  # key: ordinal
+
+    1  1  .   A 21   ALA  HB#  A 17  VAL  H   1.00 3.7  0.4   2.0  2.5  4.2  4.7
+    2  1  .   A 21   ALA  HB#  A 18  LEU  H   1.00 3.7  0.4   2.0  2.5  4.2  4.7
+    3  1  .   A 22   THR  HG2# A 17  VAL  H   1.00 3.7  0.4   2.0  2.5  4.2  4.7
+    4  1  .   A 22   THR  HG2# A 18  LEU  H   1.00 3.7  0.4   2.0  2.5  4.2  4.7
+    5  5  .   A 18   PHE  HB2  A 24  ASP  HBX 1.00 2.8  0.4   1.5  2.0  3.2  3.7
+    6  8  .   A 18   PHE  HB2  A 24  ASP  HBY 1.00 4.4  0.4   3.6  4.1  5.2  5.7
+    6  8  .   E 6B   SER  HB2  A 24  ASP  HBY 1.00 4.4  0.4   3.6  4.1  5.2  5.7
   stop_
 
-  # The first line gives the restraint ID.
+  # The first column (ordinal) is a consecutive line number that does not persist  
+  # when data are re-exported
+  # The second column gives the restraint ID.
   # Lines with the same restraint_id are combined into a single restraint
   # (OR operations, effectively an ambiguous assignment).
-  # The restraint_combination_id is used for more complex logic -
+  # The restraint_combination_id is used for more complex logic,
   # see dihedral restrains for an example.
-  # Note that there is no unique identifier for each line,
 
   # Each line (sub-restraint) of the table has its own independent
   # parameters (weight, target_value, upper_limit, etc.), which may be different
@@ -335,16 +355,17 @@ save_
 #============================================================================
 
 
-save_dihedral_restraint_list_L2
+save_nef_dihedral_restraint_list_L2
 
 # Mandatory parameters:
   _nef_dihedral_restraint_list.sf_category          nef_dihedral_restraint_list
-  _nef_dihedral_restraint_list.sf_framecode         dihedral_restraint_list_L2
+  _nef_dihedral_restraint_list.sf_framecode         nef_dihedral_restraint_list_L2
 
   _nef_dihedral_restraint_list.potential_type     	square-well-parabolic
 
   loop_
-  # Mandatory parameters
+    # Mandatory parameters, except for restraint_combination_id
+    _nef_dihedral_restraint.ordinal
     _nef_dihedral_restraint.restraint_id
     _nef_dihedral_restraint.restraint_combination_id
     _nef_dihedral_restraint.chain_code_1
@@ -365,26 +386,27 @@ save_dihedral_restraint_list_L2
     _nef_dihedral_restraint.atom_name_4
     _nef_dihedral_restraint.weight
 
-  # The following two parameters are mandatory.
-  # If they are not defined for a given potential they can be given a value of '?'
+  # The following parameters are optional. target_value and target_value_uncertainty
+  # should be given whenever a meaningful value is known'
+  # Other parameters need be given only if they are defined for the potential_type
     _nef_dihedral_restraint.target_value
     _nef_dihedral_restraint.target_value_uncertainty
-
-  # Optional parameters - use only the ones needed for the potential:
+    _nef_dihedral_restraint.lower_linear_limit
     _nef_dihedral_restraint.lower_limit
     _nef_dihedral_restraint.upper_limit
-  # _nef_dihedral_restraint.lower_linear_limit
-  # _nef_dihedral_restraint.upper_linear_limit
+    _nef_dihedral_restraint.upper_linear_limit
 
-1  .  A 21 ALA N  A 21 ALA CA  A 21 ALA  C  A 22 THR N 1.00 -50.0 5.0 -60.0 -40.0
-1  .  A 21 ALA N  A 21 ALA CA  A 21 ALA  C  A 22 THR N 1.00 105.0 5.0  90.0 120.0
-2  .  A 12 ALA C  A 22 THR N   A 22 THR CA  A 22 THR C 3.00 -50.0 8.0 -60.0 -40.0
-3  1  A 23 LYS C  A 24 ASP N   A 24 ASP CA  A 24 ASP C 1.00 -50.0 5.0 -60.0 -40.0
-3  1  A 24 ASP N  A 24 ASP CA  A 24 ASP  C  A 25 HIS N 1.00 105.0 5.0  90.0 120.0
-4  2  A 15 GLY C  A 16 ASN N   A 16 ASN CA  A 16 ASN C 1.00 -50.0 5.0 -60.0 -40.0
-4  2  A 16 ASN N  A 16 ASN CA  A 16 ASN  C  A 17 CYS N 1.00 105.0 5.0  90.0 120.0
-4  3  A 15 GLY C  A 16 ASN N   A 16 ASN CA  A 16 ASN C 1.00 -80.0 5.0 -90.0 -70.0
-4  3  A 16 ASN N  A 16 ASN CA  A 16 ASN  C  A 17 CYS N 1.00 155.0 5.0 140.0 170.0
+  # key: ordinal
+
+1  1  .  A 21 ALA N  A 21 ALA CA  A 21 ALA  C  A 22 THR N 1.00 -50.0 5.0 .  -60.0 -40.0  .
+2  1  .  A 21 ALA N  A 21 ALA CA  A 21 ALA  C  A 22 THR N 1.00 105.0 5.0 .   90.0 120.0  .
+3  2  .  A 12 ALA C  A 22 THR N   A 22 THR CA  A 22 THR C 3.00 -50.0 8.0 .  -60.0 -40.0  .
+4  3  1  A 23 LYS C  A 24 ASP N   A 24 ASP CA  A 24 ASP C 1.00 -50.0 5.0 .  -60.0 -40.0  .
+5  3  1  A 24 ASP N  A 24 ASP CA  A 24 ASP  C  A 25 HIS N 1.00 105.0 5.0 .   90.0 120.0  .
+6  4  2  A 15 GLY C  A 16 ASN N   A 16 ASN CA  A 16 ASN C 1.00 -50.0 5.0 .  -60.0 -40.0  .
+7  4  2  A 16 ASN N  A 16 ASN CA  A 16 ASN  C  A 17 CYS N 1.00 105.0 5.0 .   90.0 120.0  .
+8  4  3  A 15 GLY C  A 16 ASN N   A 16 ASN CA  A 16 ASN C 1.00 -80.0 5.0 .  -90.0 -70.0  .
+9  4  3  A 16 ASN N  A 16 ASN CA  A 16 ASN  C  A 17 CYS N 1.00 155.0 5.0 .  140.0 170.0  .
 
 stop_
 
@@ -423,21 +445,23 @@ save_
 # Optional: RDC restraint list(s)
 #=======================================================================
 
-save_rdc_restraint_list_1
+save_nef_rdc_restraint_list_1
 
 # Mandatory parameters
   _nef_rdc_restraint_list.sf_category           	nef_rdc_restraint_list
-  _nef_rdc_restraint_list.sf_framecode           	rdc_restraint_list_1
+  _nef_rdc_restraint_list.sf_framecode           	nef_rdc_restraint_list_1
 
   _nef_rdc_restraint_list.potential_type            log-normal
-# Manual comment: following values are a proposal only (for discussion) on representing orientation tensors
+# Optional parameters
    _nef_rdc_restraint_list.tensor_magnitude      11.0000  
    _nef_rdc_restraint_list.tensor_rhombicity     0.0670
    _nef_rdc_restraint_list.tensor_chain_code     C
    _nef_rdc_restraint_list.tensor_sequence_code    900
-   _nef_rdc_restraint_list.tensor_residue_type     TENSOR
+   _nef_rdc_restraint_list.tensor_residue_type     TNSR
 
   loop_
+    # Mandatory parameters, except for restraint_combination_id
+      _nef_rdc_restraint.ordinal
       _nef_rdc_restraint.restraint_id
       _nef_rdc_restraint.restraint_combination_id
       _nef_rdc_restraint.chain_code_1
@@ -450,19 +474,22 @@ save_rdc_restraint_list_1
       _nef_rdc_restraint.atom_name_
       _nef_rdc_restraint.weight
 
-  # The following two parameters are mandatory.
-  # If they are not defined for a given potential they can be given a value of '?'
+  # The following parameters are optional. target_value and target_value_uncertainty
+  # should be given whenever a meaningful value is known'
+  # Other parameters need be given only if they are defined for the potential_type
     _nef_rdc_restraint.target_value
     _nef_rdc_restraint.target_value_uncertainty
 
   # Optional parameters - use only the ones needed for the potential:
-  # _nef_rdc_restraint.lower_limit
-  # _nef_rdc_restraint.upper_limit'
-  # _nef_rdc_restraint.lower_linear_limit
-  # _nef_rdc_restraint.upper_linear_limit
+   _nef_rdc_restraint.lower_linear_limit
+   _nef_rdc_restraint.lower_limit
+   _nef_rdc_restraint.upper_limit
+   _nef_rdc_restraint.upper_linear_limit
 
-    1 .  A  21  ALA  H  A  21  ALA  N  1.00 -5.2  0.33
-    2 .  A  22  THR  H  A  22  THR  N  1.00  3.1  0.40
+  # key: ordinal
+
+    1  1 .  A  21  ALA  H  A  21  ALA  N  1.00 -5.2  0.33  .  .  .  .  1.0  false
+    2  2 .  A  22  THR  H  A  22  THR  N  1.00  3.1  0.40  .  .  .  .  1.0  false
   stop_
 
 save_
@@ -476,18 +503,18 @@ save_
 #=======================================================================
 
 
-save_nmr_spectrum_cnoesy1
+save_nef_nmr_spectrum_cnoesy1
 
 # Mandatory parameters
   _nef_nmr_spectrum.sf_category           		nef_nmr_spectrum
-  _nef_nmr_spectrum.sf_framecode			        nmr_spectrum_cnoesy1
+  _nef_nmr_spectrum.sf_framecode              nef_nmr_spectrum_cnoesy1
 
   _nef_nmr_spectrum.num_dimensions        		3
-  _nef_nmr_spectrum.chemical_shift_list		    $chemical_shift_list_1
+  _nef_nmr_spectrum.chemical_shift_list       nef_chemical_shift_list_1
+  
+  # optional parameters
   _nef_nmr_spectrum.experiment_classification   	H_H[N].through-space
   _nef_nmr_spectrum.experiment_type             	15N-NOESY-HSQC
-
-  # experiment_classification and experiment_type can be given as '?' if not known.
 
   # The chemical_shift_list gives the saveframe id within the project for the saveframe
   # that contains the relevant chemical shift list.
@@ -499,9 +526,12 @@ save_nmr_spectrum_cnoesy1
 
   loop_
 
+      # mandatory parameters
       _nef_spectrum_dimension.dimension_id
       _nef_spectrum_dimension.axis_unit
       _nef_spectrum_dimension.axis_code
+      
+      # optional parameters
       _nef_spectrum_dimension.spectrometer_frequency
       _nef_spectrum_dimension.spectral_width
       _nef_spectrum_dimension.value_first_point
@@ -509,13 +539,14 @@ save_nmr_spectrum_cnoesy1
       _nef_spectrum_dimension.absolute_peak_positions
       _nef_spectrum_dimension.is_acquisition
 
+  # key: dimension_id
+
       1  ppm  1H   500.139  10.4    9.9	circular  true    false
       2  ppm 15N    98.37   30.7  127.0	circular  true    false
       3  ppm  1H   500.139  14.2   11.8	none	    true    true
   stop_
 
-# dimension_id, axis_unit, and axis_code must be given for data to be usable.
-# Other columns can be given value '?' it not known.
+# dimension_id, axis_unit, and axis_code are mandatory.
 
 # - axis_unit could be 'Hz' 'ppm', 'point', 's', ...
 # - axis_code is the isotope (in the form '1H', '13C', ...) for shifts,
@@ -528,7 +559,7 @@ save_nmr_spectrum_cnoesy1
 #   Fourier transformation, i..e *before* then removal of any points.
 # - folding can be either 'mirror' (seq. quadrature),
 #   'circular' (std. aliasing, for sim. quadrature), or 'none'
-# - absolute_peak_positions determines if peak positionos are correct or may be
+# - absolute_peak_positions determines if peak positions are correct or may be
 #   folded/aliased.
 #   If 'false' all peaks are given in the acquisition window, whether this is
 #   their correct position or not.
@@ -544,10 +575,15 @@ save_nmr_spectrum_cnoesy1
 # Mandatory loop.
 
   loop_
+      # mandatory parameters
       _nef_spectrum_dimension_transfer.dimension_1
       _nef_spectrum_dimension_transfer.dimension_2
       _nef_spectrum_dimension_transfer.transfer_type
+      
+      # optional parameter
       _nef_spectrum_dimension_transfer.is_indirect
+
+  # key: dimension_1, dimension_2
 
       1 3 through-space  false
       2 3 onebond        false
@@ -560,6 +596,7 @@ save_nmr_spectrum_cnoesy1
 
   loop_
 
+      _nef_peak.ordinal
       _nef_peak.peak_id
       _nef_peak.volume
       _nef_peak.volume_uncertainty
@@ -584,16 +621,18 @@ save_nmr_spectrum_cnoesy1
       _nef_peak.residue_type_3
       _nef_peak.atom_name_3
 
-1 7.3E7 5.1E6 3.3E7 1.1E6  3.2 ? 119.5 ? 8.3 ? A 19 LEU HBY A 17 GLN N   A 17 GLN H
-1 7.3E7 5.1E6 3.3E7 1.1E6  3.2 ? 119.5 ? 8.3 ? A 20 CYS HBX A 17 GLN N   A 17 GLN H
-1 7.3E7 5.1E6 3.3E7 1.1E6  3.2 ? 119.5 ? 8.3 ? A 19 LEU HBY A 19 TYR N   A 19 TYR H
-1 7.3E7 5.1E6 3.3E7 1.1E6  3.2 ? 119.5 ? 8.3 ? A 20 CYS HBX A 19 TYR N   A 19 TYR H
-1 7.3E7 5.1E6 3.3E7 1.1E6  3.2 ? 119.5 ? 8.3 ? A 14 TRP HB3 A 18 PHE N   A 18 PHE H
-3 5.4E7 7.3E6 3.4E7 5.3E6  4.4 ? 106.5 ? 7.8 ? ?  ?  ?   ?  A 15 GLY N   A 15 GLY H
-4 8.8E7 1.3E7 4.8E7 3.3E6  3.2 ? 135.6 ? 9.9 ? A 14 TRP HB3 A 14 TRP NE1 A 14 TRP HE1
-5 8.8E7 1.3E7 5.8E7 2.3E7  3.4 ? 135.6 ? 9.9 ? A 14 TRP HB2 A 14 TRP NE1 A 14 TRP HE1
-5 8.8E7 1.3E7 5.8E7 2.3E7  3.4 ? 135.6 ? 9.9 ? A 24 ASP HBY A 14 TRP NE1 A 14 TRP HE1
-7 5.9E7 7.1E6 2.9E7 6.1E6  1.7 ? 118.3 ? 9.1 ? ?  ?  ?   ?  X @5 GLX N   X @5 GLX H
+  key: ordinal
+
+ 1  1 7.3E7 5.1E6 3.3E7 1.1E6  3.2 0.05 119.5 0.5 8.3 0.03 A 19 LEU HBY A 17 GLN N   A 17 GLN H
+ 2  1 7.3E7 5.1E6 3.3E7 1.1E6  3.2 0.05 119.5 0.5 8.3 0.03 A 20 CYS HBX A 17 GLN N   A 17 GLN H
+ 3  1 7.3E7 5.1E6 3.3E7 1.1E6  3.2 0.05 119.5 0.5 8.3 0.03 A 19 LEU HBY A 19 TYR N   A 19 TYR H
+ 4  1 7.3E7 5.1E6 3.3E7 1.1E6  3.2 0.05 119.5 0.5 8.3 0.03 A 20 CYS HBX A 19 TYR N   A 19 TYR H
+ 5  1 7.3E7 5.1E6 3.3E7 1.1E6  3.2 0.05 119.5 0.5 8.3 0.03 A 14 TRP HB3 A 18 PHE N   A 18 PHE H
+ 6  3 5.4E7 7.3E6 3.4E7 5.3E6  4.4 0.05 106.5 0.5 7.8 0.03 .  .   .   . A 15 GLY N   A 15 GLY H
+ 7  4 8.8E7 1.3E7 4.8E7 3.3E6  3.2 0.05 135.6 0.5 9.9 0.03 A 14 TRP HB3 A 14 TRP NE1 A 14 TRP HE1
+ 8  5 8.8E7 1.3E7 5.8E7 2.3E7  3.4 0.05 135.6 0.5 9.9 0.03 A 14 TRP HB2 A 14 TRP NE1 A 14 TRP HE1
+ 9  5 8.8E7 1.3E7 5.8E7 2.3E7  3.4 0.05 135.6 0.5 9.9 0.03 A 24 ASP HBY A 14 TRP NE1 A 14 TRP HE1
+10  7 5.9E7 7.1E6 2.9E7 6.1E6  1.7 0.05 118.3 0.5 9.1 0.03 E 6B SER   . X @5 GLX N   X @5 GLX H
   stop_
 
 # Peaks 1 and 5 have ambiguous assignments.
@@ -614,7 +653,7 @@ save_
 #=======================================================================
 # Section 9
 #
-# Optional: Linkage tabl+-e for peaks and restraints
+# Optional: Linkage table for peaks and restraints
 #
 # Singleton (only one per project)
 #
@@ -631,13 +670,13 @@ loop_
   _nef_peak_restraint_link.peak_id
   _nef_peak_restraint_link.restraint_list_id
   _nef_peak_restraint_link.restraint_id
-  $nmr_spectrum_cnoesy1     1   $distance_restraint_list_L1     73
-  $nmr_spectrum_cnoesy1     1   $distance_restraint_list_L1    233
-  $nmr_spectrum_cnoesy1   577   $distance_restraint_list_L2     12
-  # $nmr_spectrum_nnoesy1   126   $distance_restraint_list_L1    359
-  # $nmr_spectrum_nnoesy1    44   $distance_restraint_list_L4   2755
-  $nmr_spectrum_cnoesy1   316   $distance_restraint_list_L4   2755
-  # $nmr_spectrum_rdc1       12   $rdc_restraint_list_L5          37
+  
+  # key: nmr_spectrum_id, peak_id, restraint_list_id, restraint_id
+  
+  nef_nmr_spectrum_cnoesy1     1   nef_distance_restraint_list_L1     73
+  nef_nmr_spectrum_cnoesy1     1   nef_distance_restraint_list_L1    233
+  nef_nmr_spectrum_cnoesy1   577   nef_distance_restraint_list_L2     12
+  nef_nmr_spectrum_cnoesy1   316   nef_distance_restraint_list_L4   2755
 stop_
 
 # The table gives links between peaks (in any spectrum) and restraints

--- a/specification/Overview.md
+++ b/specification/Overview.md
@@ -3,29 +3,61 @@ Nmr Exchange Format (NEF) proposal
 
 ###Organization of this document
 
-The first sections present general issues that are not linked to a specific part of the example files. Section 2 lists comments to the companion documents, organised by data category (saveframe).
+The first sections present general issues that are not linked to a specific part
+of the example files. Section 2 lists comments to the companion documents,
+organised by data category (saveframe).
 
 ### General issues
 
   1. Residue and Atom names
 
-    Residues are identified by three strings (chain_code, sequence_code, residue_type) that always are used together. Atoms are identified by a residue identifier plus the atom name as a fourth string.
+    Residues are identified by three strings (chain_code, sequence_code,
+    residue_type) that always are used together. Atoms are identified by a
+    residue identifier plus the atom name as a fourth string.
 
-    1.  The identifying strings are case sensitive, and all identifiers (including casing) must be consistent throughout a file. Atom names and standard 3-letter-type residue names should be ALL-UPPER-CASE, and it is recommended that this convention is followed throughout. Lower case is allowed for chain codes, and future names (e.g. carbohydrate residues) may allow lower case.
+    1.  The identifying strings are case sensitive, and all identifiers
+    (including casing) must be consistent throughout a file. Atom names and
+    standard 3-letter-type residue names should be ALL-UPPER-CASE, and it is
+    recommended that this convention is followed throughout. Lower case is
+    allowed for chain codes, and future names (e.g. carbohydrate residues) may
+    allow lower case.
 
-    2.  sequence_code is a string, not an integer. It is recommended to use consecutive numbers along a chain, or, failing that, to put any alt_codes as suffixes (as in '127B').
+    2.  sequence_code is a string, not an integer. It is recommended to use
+    consecutive numbers along a chain, or, failing that, to put any alt_codes
+    as suffixes (as in '127B').
 
-    3.  sequence_codes, too, must be consistently used throughout the file. It follows that any program-specific numberings must be given and used in the program-specific namespace, and that renaming and renumbering after deposition must preserve the original names (possibly using a deposition-specific namespace for the new names).
+    3.  sequence_codes, too, must be consistently used throughout the file. It
+    follows that any program-specific numberings must be given and used in the
+    program-specific namespace, and that renaming and renumbering after
+    deposition must preserve the original names (possibly using a
+    deposition-specific namespace for the new names).
 
     4.  For the common standard residues (22 amino acids, 4 DNA and 4 RNA nucleotides) the NEF standard will adopt the IUPAC nomenclature for residue types and wwPDB nomenclature for  variants, as well as IUPAC atom names. For the standard residues we will use UPPER-CASE for atom names. For non-standard residues applications can make their own choices, although IUPAC or wwPDB nomenclature is recommended. It has to be decided which variants are formally part of the standard.
 
-    5.  residue_type must be specified as the basic type in all cases (e.g. use HIS regardless of protonation state). Variant types are defined in the _sequence loop.
+    5.  residue_type must be specified as the basic type in all cases (e.g. use
+      HIS regardless of protonation state).
 
-    6.  A residue is uniquely identified by the chain_code and sequence_code, so that the same residue_type string must be used consistently throughout the file. Strictly speaking this makes the residue_type string redundant, but it is used in identifiers to avoid ambiguity and to serve as a cross-check.
+    6.  A residue is uniquely identified by the chain_code and sequence_code,
+    so that the same residue_type string must be used consistently throughout
+    the file. Strictly speaking this makes the residue_type string redundant,
+    but it is used in identifiers to avoid ambiguity and to serve as a
+    cross-check.
 
-    7.  Atoms are identified by their name. The stereo/nonstereo assignment status and atom/atomset/pseudoatom distinction follows from the name, so that there is no need for assignment status codes anywhere in the file
+    7.  Atoms are identified by their name. The stereo/nonstereo assignment
+    status and atom/atomset/pseudoatom distinction follows from the name, so
+    that there is no need for assignment status codes anywhere in the file
 
-    8.  Atoms that differ only by stereochemistry (prochiral protons or methyl groups, NH2 groups, opposite sides of non-rotating aromatic rings) but are not stereospecifically assigned, are distinguished using the suffixes 'X' and 'Y'.  These suffixes work effectively as a wildcard, so the 'X' and 'Y' stands for one specific digit, and cannot be used for other purposes. The choice of suffix for a given resonance is arbitrary, except that atoms in a stereochemically separate branch are all given the same suffix. For instance, Val CGX is bound to HGX#, and TYR CDX is bound to HDX and CEX. The existing upfield/downfield convention (suffixes 'a' and 'b') is not supported. In NMR-STAR terms X and Y suffixes correspond to ambiguity codes 2 (geminal atoms) and 3 (symmetrical aromatic rings).
+    8.  Atoms that differ only by stereochemistry (prochiral protons or methyl
+      groups, NH2 groups, opposite sides of non-rotating aromatic rings) but
+      are not stereospecifically assigned, are distinguished using the suffixes
+      'X' and 'Y'.  These suffixes work effectively as a wildcard, so the 'X'
+      and 'Y' stands for one specific digit, and cannot be used for other
+      purposes. The choice of suffix for a given resonance is arbitrary, except
+      that atoms in a stereochemically separate branch are all given the same
+      suffix. For instance, Val CGX is bound to HGX%, and TYR CDX is bound to
+      HDX and CEX. The existing upfield/downfield convention (suffixes 'a'
+      and 'b') is not supported. In NMR-STAR terms X and Y suffixes correspond
+      to ambiguity codes 2 (geminal atoms) and 3 (symmetrical aromatic rings).
 
     9.  Sets of atoms can be represented by using atom names with wildcards. We propose to support two kinds of wildcards: '#' for 'any sequence of digits', and '\*' for 'any whitespace-free string'. In normal current usage wildcard expressions will be used for NMR-equivalent atoms, and '\*' expressions must only  be used where '#' expressions would not suffice. In practice this means that all common cases of equivalent atoms are expressed with '#' (ALA HB#, ASN HB#, ASN HD#, LEU HD1#, LEU HD#, LEU CD#, TYR CD#, TYR HD#, LYS HZ#, ...). Notably N-terminal -NH3+ would be 'H#'.  '\*' would only be used where necessary, mainly for 'H\*', 'C\*', '\*',  ... (all protons, all carbons,  all atoms, etc.).
 
@@ -33,11 +65,30 @@ The first sections present general issues that are not linked to a specific part
 
     11. Pseudoatom/wildcard names, stereospecific or non-stereospecific atom names can coexist for the same atom in the same file, but the proper name must be used with its defined meaning throughout the NEF file. It follows that when renaming the atoms to stereospecific entities, e.g. once the coordinates are known, the program must also maintain the name previously used to preserve continuity.
 
-        We propose storing an additional 'Nmr_name' alongside the existing atom identifier ('_atom_site.label_atom_id' ?)' in separate tags in the coordinate file, where Nmr_name refers to the name used in the NEF file. Notably, this requires addition to the mmCif dictionary. Individual models in the ensemble can thus each have their own unique combinations of Nmr_name and label_atom_id (?), thus allowing for floating stereospecific assignments that can vary between the individual members of the ensemble.  
+      The RCSB has agreed to store an 'nef_atom_name' alongside the existing
+    atom identifier ('_atom_site.label_atom_id' ?)' in separate tags in the
+    coordinate file, where nef_atom_name refers to the name used in the NEF
+    file. Individual models in the ensemble can thus each have their own unique
+    combinations of nef_atom_name and label_atom_id, allowing for floating
+    stereospecific assignments that can vary between the individual models in
+    the ensemble.  
 
-    12. Residues and atoms that match the molecular sequence (including those using pseudoatom and non-stereospecific naming conventions) are understood as referring to chain/residue/atom in the molecule. Names that do not match the sequence are allowed; they are interpreted as referring to observed but (partially) unassigned resonances. They are ignored where they are inapplicable in context (e.g. in restraint lists), but must be maintained in the shift list.
+    12. Residues and atoms that match the molecular sequence (including those
+    using pseudoatom and non-stereospecific naming conventions) are understood
+    as referring to chains/residues/atoms in the molecule. Names that do not
+    match the sequence are allowed; they are interpreted as referring to
+    observed but (partially) unassigned resonances. They can be ignored where
+    they are inapplicable in context (e.g. in restraint lists), but must be
+    maintained in the shift list.
 
-    13. Selection expressions. For the time being wildcards are allowed only for atom names. It would be possible to extend their use to chain_code, sequence_code and residue_type at a later date, if there is a use case for this. More complex selection expressions, such as residue ranges, are surely too complicated for this kind of format. Note that these can be expressed as ambiguous peak assignments or restraints. For the specific case of residue ranges we should notice that sequence_code is a string, not an integer, which renders the concept of ranges rather unwieldy.
+    13. Selection expressions. For the time being wildcards are allowed only
+    for atom names. It would be possible to extend their use to chain_code,
+    sequence_code and residue_type at a later date, if there is a use case for
+    this. More complex selection expressions, such as residue ranges, are
+    surely too complicated for this kind of format. Note that these can be
+    expressed as ambiguous peak assignments or restraints. For the specific
+    case of residue ranges we should notice that sequence_code is a string, not
+    an integer, which renders the concept of ranges rather unwieldy.
 
   2. Identifiers
     1. NEF data block IDs (the string that follows "data\_") *must* start with
@@ -80,21 +131,59 @@ The first sections present general issues that are not linked to a specific part
 
   4. Mandatory contents
 
-    We propose to divide format versions in major and minor, with both running as consecutive integers (e.g. 1.0, ... 1.8, 1.9, 1.10, 1.11, ... ... 1.314, ...). Minor version changes to the format should be incremental and non-breaking, so that code that reads version 1.4 more or less automatically will read version 1.3 also. This includes not having duplicate storage slots, so that the same information would be found in the same place in both versions. This only holds for public tags, program-specific tags can be changed freely by the program owner.
+    A valid NEF data block must contain nef_nmr_meta_data, and a valid
+    nef_molecular_system saveframe. It must also contain at least one 
+    nef_chemical_shift_list. A file whose chemical shift list(s) contain no
+    data is technically valid, but will not be accepted for deposition.
 
-    Major format version changes (e.g. from 1.8 to 2.0) may break previous readers. We would expect that many programs would support only one major version, and that separate upgrade and downgrade routines be produced to convert between major versions.
 
   5. Single and multiple files
 
-    Each data block is a self-contained project description, and must have a unique name, in context. Data will normally be passed with one data block per file, and programs will read only the first data block they encounter. It is legal to have multiple data blocks in a file, but under normal circumstances only one will be read.
+    Each data block is a self-contained project description, and must have a
+    unique name, in context. Data will normally be passed with one data block
+    per file, and programs will read only the first nef data block they
+    encounter. It is legal to have multiple data blocks in a file, but under
+    normal circumstances only one will be read.
 
-    The rules call for keeping data always in a single coherent file, but it is not possible to prevent users from gathering data from multiple files. The format rules will hold for each file (including the rules on mandatory molecular system description, shift list, etc.), but programs may, at their own risk, put in empty molecular descriptions and shift lists.
+    The rules call for keeping data always in a single coherent file, but it is
+    not possible to prevent users from gathering data from multiple files. The
+    format rules will hold for each file (including the rules on mandatory
+    molecular system description, etc.), but programs may, at their own risk,
+    put in empty molecular descriptions.
 
-    It has been pointed out that programs can not, in general, read in and preserve information that they do not make use of, especially program-specific tags for other programs, and there will be a need for a utility to merge such information between two files.
+    Programs must faithfully read and (re-)export the information they use.
+    Information that is not used should be kept and re-exported if possible but
+    may be omitted.
+    Programs should not re-export incorrect values for information they do not use
+    (e.g. truncated residue names, partial sequences, ...)
 
-  6. Support for model definition, reference parsers, etc.
+  6. Field values and data types
+    1. Unlike NMR-STAR, the dollar sign ('$') is *not* used as a prefix to
+    indicate a saveframe identifier.
 
-      Nef bring a STAR format, we would propose using the same formal specification mechanisms, reference parsers and validators as the BioMagResBank, insofar as possible. Specifically, we wold propose the STAR parsers as a reference implementation for file parsing. Many programs may prefer to write their own I/O code and do their validation internally on reading, but a central reference would still be useful. The NEF consortium would need to agree on arrangements for distribution and support.
+    2. Again unlike NMR-STAR, the question mark ('?') is *not* used to indicate
+    missing data - all missing data are indicted by a dot ('.'), which may be
+    translated as a null value.
+
+  7. Format  versions
+
+    We propose to divide format versions in major and minor, with both running
+    as consecutive integers (e.g. 1.0, ... 1.8, 1.9, 1.10, 1.11, ... ... 1.314,
+      ...). Minor version changes to the format should be incremental and
+      non-breaking, so that code that reads version 1.4 automatically reads
+      version 1.3 also. This includes not having duplicate storage slots, so
+      that the same information would be found in the same place in both
+      versions. Each change should cause an increase in the minor version
+      of the format, so that the minor format number is wexpected to increase
+      fast over time.
+
+      Program-specific tags are not included in this rule, and can be
+      changed freely by the program owner.
+
+      Major format version changes (e.g. from 1.8 to 2.0) may break previous
+      readers. We would expect that many programs would support only one major
+      version, and that separate upgrade and downgrade routines be produced to
+      convert between major versions.
 
 
 
@@ -102,7 +191,8 @@ The first sections present general issues that are not linked to a specific part
 
   1. Regarding Section 3. Mandatory: **Molecular system**
 
-    1.  There is only one molecular system per project. Different complexes, ligands, etc. are handled by using different chain codes.
+    1.  There is only one molecular system per project. Different complexes,
+    ligands, etc. are handled by using different chain codes.
 
     2.  The _sequence loop is a compromise between a full, complex topology description and simply assuming linear polymers - see the example files, section 3. Of the three information columns the residue_type is always the canonical name, while the residue_variant shows variants, according to the wwPBD system. The linking column shows linear connection information, and can have the following values:
 
@@ -121,17 +211,41 @@ The first sections present general issues that are not linked to a specific part
 
   2. Regarding Section 5. Optional: **Distance restraint lists(s)**
 
-    1.  All types of restraints need persistent identifier numbers (see separate discussion above)
+    1. The ordinal column is a series of consecutive integers that serve to
+    make each line unique. These values are *not* preserved when reading and
+    re-writing data.
 
-    2.  Potential types (parabolic, log-normal, ...)  are given for the entire list, as these determine the number and kind of parameters. This means that restraints using different potential types must be given in separate lists.
+    1. All types of restraints need persistent identifier numbers (see separate
+      discussion above)
 
-    3.  We will have column names for the parameters used by most common potential types, specifically 'target_value', ' target_value_uncertainty', 'lower_limit', 'upper_limit', lower_linear_limit', and 'upper_linear_limit'. target_value and target_value_uncertainty are mandatory (but can be given as '?' where undefined), the others are optional and should only be added to the loop where necessary.
+    2.  Potential types (parabolic, log-normal, ...)  are given for the entire
+    list, as these determine the number and kind of parameters. This means that
+    restraints using different potential types must be given in separate lists.
 
-    4.  Each line (sub-restraint) of the table has its own independent parameters (weight, target_value, upper_limit, etc.), although in most common cases the values will be identical on lines that belong to the same restraint. It is up to each program to deal with the data as they are.
+    3. The 'restraint_origin' field gives the source of the restraints, e.g.
+    'noe', 'hbond', 'mutation', 'shift_perturbation' for a distance restraint
+    list, or 'talos', 'jcoupling', ... for a dihedral restraint list.
 
-    5.  In the most common case, sub-restraints within the same restraint are treated as ambiguous, and can be OR'ed or summed as the program may prefer.  For a discussion of more complex restraint logic, using the restraint_combination_id, see section 6.
+    4.  We have column names for the parameters used by most common
+    potential types, specifically 'target_value', ' target_value_uncertainty',
+    'lower_limit', 'upper_limit', lower_linear_limit', and 'upper_linear_limit'.
+    All are optional, depending on the potential type, but target_value and
+    target_value_uncertainty should be given whenever a meaningful value is
+    defined, even if this value is not used in the calculation.
 
-    6. The current draft supports the potential types
+    5.  Each line (sub-restraint) of the table has its own independent
+    parameters (weight, target_value, upper_limit, etc.), although in most
+    common cases the values will be identical on lines that belong to the same
+    restraint. It is up to each program to deal with the data as they are.
+
+    6.  In the most common case, sub-restraints within the same restraint are
+    treated as ambiguous, and can be OR'ed or summed as the program may prefer.
+    For a discussion of more complex restraint logic, using the
+    restraint_combination_id, see section 6.
+
+    7. The current draft supports the potential types
+
+      - 'undefined'
 
       - 'log-harmonic'
 


### PR DESCRIPTION
	* Datablock name must now start with 'nef_'
	* All sf_framecode must now start with the name of the corresponding
		sf_category
	* '?' is no longer supported to mean 'not set' - all unset parameters must
		now be given as '.', which translates as null (None)
	* mandatory and optional tags and key columns for loops defined and given in
		Commented_Example.nef
	* The convention of starting references to saveframes with a '$' is NOT 
		supported any longer.
	* added ordinal column to peak and restraint lists to provide unique
		identifier for each line