### PR TITLE
Bug-fixed and finalised specifications.

### DIFF
--- a/specification/Commented_Example.nef
+++ b/specification/Commented_Example.nef
@@ -1,12 +1,9 @@
 #==========================================================================
 #  Nmr Exchange Format
 #
-#  Draft version 0.8  March 2015 Rasmus Fogh,
+#  Draft version 0.91  August 2016 Rasmus Fogh,
 #
-#  The file shows an example of how data might be organised, with limited comments
-#  for clarification.
-#
-#  The style is nmr-star.
+#  Commented example file with representative examples and a value for all tags
 #
 
 data_nef_my_nmr_project_1
@@ -22,54 +19,55 @@ data_nef_my_nmr_project_1
 #========================================================================
 
 
-save_nef_nmr_meta_data
+   save_nef_nmr_meta_data
 
-# Mandatory:
-  _nef_nmr_meta_data.sf_category           		nef_nmr_meta_data
-  _nef_nmr_meta_data.sf_framecode           	nef_nmr_meta_data
+      # Mandatory:
+      _nef_nmr_meta_data.sf_category      nef_nmr_meta_data
+      _nef_nmr_meta_data.sf_framecode     nef_nmr_meta_data
 
-  _nef_nmr_meta_data.format_name                  Nmr_Exchange_Format
-  _nef_nmr_meta_data.format_version               0.8
-  _nef_nmr_meta_data.program_name                 CYANA
-  _nef_nmr_meta_data.program_version              3.01
-  _nef_nmr_meta_data.creation_date                2013-02-29T13:12:03.521773
-  _nef_nmr_meta_data.uuid                         CYANA-2013-02-29T13:12:04.521773-1172436
+      _nef_nmr_meta_data.format_name      nmr_exchange_format
+      _nef_nmr_meta_data.format_version   0.91
+      _nef_nmr_meta_data.program_name     CcpNmr
+      _nef_nmr_meta_data.program_version  3.0.b1
+      _nef_nmr_meta_data.creation_date    2016-07-20T18:25:26.324290
+      _nef_nmr_meta_data.uuid             CcpNmr-2016-07-20T18:25:26.324290-1226605315
 
-# Optional:
-  _nef_nmr_meta_data.coordinate_file_name         depositiondir/somefile.ext
+      # Optional:
+      _nef_nmr_meta_data.coordinate_file_name  depositiondir/somefile.ext
 
-# Optional loops (to end of saveframe):
+      # Optional loops (to end of saveframe):
 
-# Related database entries
-  loop_
-    # mandatory parameters
-  _nef_related_entries.database_name
-  _nef_related_entries.database_accession_code
+      # Related database entries
+      loop_
 
-  # key: database_name, database_accession_code
+         # mandatory parameters
+         _nef_related_entries.database_name
+         _nef_related_entries.database_accession_code
+ 
+         # key: database_name, database_accession_code
 
-    BMRB   12345
-    BMRB   22277
-    PDB    2k5v
-    PDB    2hhx
-    PDB    1aap
-   stop_
+         BMRB   12345
+         BMRB   22277
+         PDB    2k5v
+         PDB    2hhx
+         PDB    1aap
+      stop_
 
-# Program scripts used
-  loop_
-    # mandatory parameter
-    _nef_program_script.program_name
+      # Program scripts used
+      loop_
+         # mandatory parameter
+         _nef_program_script.program_name
     
-    # optional parameters
-    _nef_program_script.script_name
-    _nef_program_script.script
-    
-    # program,-specific parameter
-    _nef_program_script.cyana_parameter_1
+         # optional parameters
+         _nef_program_script.script_name
+         _nef_program_script.script
 
-  # key: program_name, script_name
+         # program-specific parameter
+         _nef_program_script.cyana_parameter_1
 
-    	CYANA  init.cya
+         # key: program_name, script_name
+
+    	 CYANA  init.cya
 ;
 rmsdrange:=1-93
 
@@ -78,8 +76,8 @@ cyanalib
 read seq protein.seq
 
 ;
-   	5
-	Cyana  init2.cya
+         5
+         Cyana  init2.cya
 ;
 rmsdrange:=3-90
 
@@ -88,37 +86,38 @@ cyanalib
 read seq protein.seq
 
 ;
-   	12
-  stop_
+   
+         12
+      stop_
 
 
 
-# Data history loop
-  loop_
-    # mandatory parameters
-    _nef_run_history.run_ordinal
-    _nef_run_history.program_name
+      # Data history loop
+      loop_
+         # mandatory parameters
+         _nef_run_history.run_ordinal
+         _nef_run_history.program_name
     
-    # optional parameters
-    _nef_run_history.program_version
-    _nef_run_history.script_name
-    _nef_run_history.script
+         # optional parameters
+         _nef_run_history.program_version
+         _nef_run_history.script_name
+         _nef_run_history.script
 
-  # key: run_ordinal
+         # key: run_ordinal
 
-    1   TOPSPIN  3.1   mypulprog.name
+         1   TOPSPIN  3.1   mypulprog.name
 ;
 INSERT PULSE PROGRAM HERE
 
 ;
 
-    2   UNIO  . . .
-  stop_
+         2   UNIO  . . .
+      stop_
 
-# NOTE: The values in this loop refer to previous runs, and so contain
-# different information from the _nef_program_script loop.
+      # NOTE: The values in this loop refer to previous runs, and so contain
+      # different information from the _nef_program_script loop.
 
-save_
+   save_
 
 #========================================================================
 # Section 2
@@ -127,15 +126,15 @@ save_
 #
 #=========================================================================
 
-save_cyana_additional_data_1
+   save_cyana_additional_data_1
 
-# Mandatory:
-  _cyana_additional_data.sf_category           	cyana_additional_data
-  _cyana_additional_data.sf_framecode           cyana_additional_data_1
+      # Mandatory:
+      _cyana_additional_data.sf_category           	cyana_additional_data
+      _cyana_additional_data.sf_framecode           cyana_additional_data_1
 
-  _cyana_additional_data.special_version  5
+      _cyana_additional_data.special_version  5
 
-save_
+   save_
 
 
 #=========================================================================
@@ -149,66 +148,81 @@ save_
 #=======================================================================
 
 
-save_nef_molecular_system
+   save_nef_molecular_system
 
-# Mandatory:
-  _nef_molecular_system.sf_category           	nef_molecular_system
-  _nef_molecular_system.sf_framecode          	nef_molecular_system
+      # Mandatory:
+      _nef_molecular_system.sf_category   nef_molecular_system
+      _nef_molecular_system.sf_framecode  nef_molecular_system
 
-# Mandatory:
-  loop_
-    _nef_sequence.chain_code
-    _nef_sequence.sequence_code
-    _nef_sequence.residue_type
-    _nef_sequence.linking
-    _nef_sequence.residue_variant
+      # Mandatory:
+      loop_
+	 # mandatory parameters
+         _nef_sequence.chain_code
+         _nef_sequence.sequence_code
+         _nef_sequence.residue_type
+         
+	 # optional parameters
+         _nef_sequence.linking
+         _nef_sequence.residue_variant
 
-  # key: chain_code, sequence_code
+         # key: chain_code, sequence_code
 
-    A   13  ALA  	start		.
-    A	  14	TRP	  middle	.
-    A	  15	GLY	  middle	.
-    A	  16	ASN	  middle	.
-    A	  17	VAL	  middle	.
-    A	  18	PHE	  middle	.
-    A  	19	LEU	  middle		.
-    A   20  CYS   middle		.
-    A   21  ALA   middle		.
-    A   22  THR   middle		.
-    A   23  LYS   middle		.
-    A   24  ASP   middle		.
-    A   25  HIS   end			.
-    A	  26	GLC	  nonlinear	.
-    B	  17	CYS		single	.
-    C    1  ATP   nonlinear		.
- # Manual comment: Pseudo-residues (linkers and tensor origin) added. 
-    C  898  UNK   dummy			.
-    C  899  UNK   dummy			.
-    C  900  TNSR  dummy			.
-    D    1  GLY   cyclic		.
-    D    2  PRO   middle		.
-    D    3  ASP   middle		ASP_LL
-    D    4  GLY   middle		.
-    D    5  PRO   middle		.
-    D    6  ASP   cyclic		.
-    E    1  ASN   break			.
-    E    2  THR   middle		.
-    E    3  ALA   middle		.
-    E    4  PRO   middle		.
-    E    5  ALA   middle		.
-    E    6  GLU   middle		.
-    E    6B SER   middle		.
-    E    7  GLN   middle		.
-	E	 8	GLU	  middle		GLU_LL
-	E	 9	HIS	  middle		HIS_LL_DHD1
-	E	10	HIS	  middle		HIS_LL_DHE2
-	E	11	CYS	  middle		CYS_LL
-	E	12	LYS	  middle		LYS_LL_DHZ3
-	E	13	ARG	  break			ARG_LL_DHH12
-	E 14  MOH   nonlinear .
-  stop_
+         A  13   ALA  start      .
+         A  14   TRP  middle     .
+         A  15   GLY  middle     .
+         A  16   ASN  middle     .
+         A  17   VAL  middle     .
+         A  18   PHE  middle     .
+         A  19   LEU  middle     .
+         A  20   CYS  middle     .
+         A  21   ALA  middle     .
+         A  22   THR  middle     .
+         A  23   LYS  middle     .
+         A  24   ASP  middle     .
+         A  24B  GLN  middle     .
+         A  24C  GLN  middle     .
+         A  24D  TYR  middle     .
+         A  25   HIS  end        .
+         A  26   GLC  nonlinear  .
+         B  17   CYS  single     .
+         C  1    ATP  nonlinear  .
+         # Manual comment: Pseudo-residues (linkers and tensor origin) added. 
+         C  898  UNK   dummy     .
+         C  899  UNK   dummy     .
+         C  900  TNSR  dummy     .
+         D  1    GLY  cyclic     .
+         D  2    PRO  middle     .
+         D  3    ASP  middle     ASP_LL
+         D  4    GLY  middle     .
+         D  5    PRO  middle     .
+         D  6    ASP  cyclic     .
+         E  1    ASN  break      .
+         E  2    THR  middle     .
+         E  3    ALA  middle     .
+         E  4    PRO  middle     cispeptide
+         E  5    ALA  middle     .
+         E  6    GLU  middle     .
+         E  7    SER  middle     .
+         E  8    GLN  middle     .
+         E  9    GLU  middle     GLU_LL
+         E  10   HIS  middle     HIS_LL_DHD1
+         E  11   HIS  middle     HIS_LL_DHE2
+         E  12   CYS  middle     CYS_LL
+         E  13   LYS  middle     LYS_LL_DHZ3
+         E  14   ARG  break      ARG_LL_DHH12
+         E  14   MOH  nonlinear  .
+         F   1   GLY  start      .
+         F   2   ILE  middle     .
+         F   3   SER  middle     .
+         F   4   THR  break      .
+         F  11   ASN  middle     .
+         F  12   SER  end        .
+         G  27   TYR  middle     .
+         G  28   GLY  middle     .
+         G  29   ALA  middle     .
+      stop_
 
-# Chain A is a linear dodecapeptide (15-25), disulfide linked to a single
+# Chain A is a linear pentadecapeptide (15-25), disulfide linked to a single
 # cysteine, with a glucose linked to THR 22
 # The GLC is given with chaincode A, the CYS with code B; both forms are allowed
 #
@@ -216,35 +230,45 @@ save_nef_molecular_system
 #
 # Chain D is a cyclic hexapeptide
 #
-# Chain E has an amide bond between the backbone N of ASN 1 and the side chain carboxylate
+# Chain E has an amide bond between the between the backbone N of ASN 1 and the side chain carboxylate
 # of GLU 6, and a methyl ester cap.
 #
-# residue_variants default to the pH 7 forms, specifically protonated LYS, ARG, HIS, and N-terminus
-# and deprotonated ASP, GLU, CYS, and C-terminus. 'deprotonated' CYS is generally assumed to be the 
-# disulfide form (The RCSB variant codes do not distinguish between disulfide and deprotonated CYS)
-# Chain E shows examples of how to specify the non-default forms supported by the NEF format.
-# Note that each variant comes in three forms: 'middle' (conntains '_LL'), 'end (contains '_LEO2'),
+# Chains F and G represent a chimeric protein, where (part of) chain G has been
+# inserted into chain F while maintaining the original numbering. Each chain is given as a
+# single block of residues, with the 'break' linking to show the chain break, and the 
+# nef_covalent_links loop to show the additional sequential links.
+#
+# residue_variants default to the pH 7 forms, specifically protonated LYS, ARG, and N-terminus
+# and deprotonated ASP, GLU, and C-terminus. 'deprotonated' CYS is generally assumed to be the 
+# disulfide form (The RCSB variant codes do not distinguish between disulfide and deprotonated 
+# Note that each variant comes in three forms: 'middle' (contains '_LL'), 'end (contains '_LEO2'),
 # and 'start' (contains '_LSN3')
+#
+# Chain E shows examples of how to specify the non-default forms supported by the NEF format.
 
 # Covalent cross-links loop. Optional:
-  loop_
-    _nef_covalent_links.chain_code_1
-    _nef_covalent_links.sequence_code_1
-    _nef_covalent_links.residue_type_1
-    _nef_covalent_links.atom_name_1
-    _nef_covalent_links.chain_code_2
-    _nef_covalent_links.sequence_code_2
-    _nef_covalent_links.residue_type_2
-    _nef_covalent_links.atom_name_2
+      loop_
+         # mandatory parameters
+         _nef_covalent_links.chain_code_1
+         _nef_covalent_links.sequence_code_1
+         _nef_covalent_links.residue_type_1
+         _nef_covalent_links.atom_name_1
+         _nef_covalent_links.chain_code_2
+         _nef_covalent_links.sequence_code_2
+         _nef_covalent_links.residue_type_2
+         _nef_covalent_links.atom_name_2
 
-  # key: chain_code_1, sequence_code_1, atom_name_1, chain_code_2, sequence_code_2, atom_name_2
+         # key: chain_code_1, sequence_code_1, atom_name_1, chain_code_2, sequence_code_2, atom_name_2
 
-    A 20 CYS SD B 17 CYS SD
-    A 22 THR OG1 A 26 GLC C1
-    E  1 ASN N   E  6 GLU CD
-  stop_
+         A 20 CYS SD B 17 CYS SD
+         A 22 THR CB A 26 GLC O1
+         E  1 ASN N   E  6 GLU CD
+         E 13 ARG C   E 14 MOH O
+         F  4 THR C   G 27 TYR N
+         G 29 ALA C   F 11 ASN N
+      stop_
 
-save_
+   save_
 
 
 
@@ -254,46 +278,72 @@ save_
 # Mandatory: Chemical shift table(s)
 #===========================================================================
 
-save_nef_chemical_shift_list_1
+   save_nef_chemical_shift_list_1
 
-# All tags in this saveframe are mandatory, except for value_uncertainty.
+      # All tags in this saveframe are mandatory, except for value_uncertainty.
 
-  _nef_chemical_shift_list.sf_category           	nef_chemical_shift_list
-  _nef_chemical_shift_list.sf_framecode          	nef_chemical_shift_list_1
+      _nef_chemical_shift_list.sf_category                nef_chemical_shift_list
+      _nef_chemical_shift_list.sf_framecode               nef_chemical_shift_list_1
+      _nef_chemical_shift_list.atom_chemical_shift_units  ppm
 
-  _nef_chemical_shift_list.atom_chem_shift_units      ppm
-
-  loop_
-      _nef_chemical_shift.chain_code
-      _nef_chemical_shift.sequence_code
-      _nef_chemical_shift.residue_type
-      _nef_chemical_shift.atom_name
-      _nef_chemical_shift.value
-      _nef_chemical_shift.value_uncertainty
+      loop_
+         _nef_chemical_shift.chain_code
+         _nef_chemical_shift.sequence_code
+         _nef_chemical_shift.residue_type
+         _nef_chemical_shift.atom_name
+         _nef_chemical_shift.value
+         _nef_chemical_shift.value_uncertainty
       
-  # key: chain_code, sequence_code, atom_name
+         # key: chain_code, sequence_code, atom_name
 
-      A	15	GLY	QA	 3.42	0.02
-      A 17      VAL     HG%      0.73   0.02
-      A 17      VAL     CG%     22.1    0.3
-      A 18      PHE     HB2      2.87   0.02
-      A 18      PHE     HB3      2.42   0.02
-      A 19      LEU     HBX      2.13   0.02
-      A 19      LEU     HBY      2.51   0.02
-      A 19      LEU     HDX%     0.87   0.02
-      A 19      LEU     HDY%     0.73   0.02
-      A 19      LEU     CDX     17.4    0.3
-      A 19      LEU     CDY     18.7    0.3
-      A 21      ALA     HA       4.17   0.02
-      A 21      ALA     H        8.33   0.02
-      A 21      ALA     HB%      1.34   0.02
-      A 23      LYS     HA       4.27   0.02
-      A 23      LYS     H        8.45   0.04
-      A 23      LYS     CA      43.2    0.25
-      A 23      LYS     N      123.45   0.4
-     @1 SS@231  GLX?    CAi-1   48.2     .
-     @1 SS@12      .    CAi-1   48.2     .
-  stop_
+         A     14      TRP   HB2    3.4     0   
+         A     14      TRP   HB3    3.2     0   
+         A     14      TRP   HE1    9.9     0   
+         A     14      TRP   NE1    135.6   0   
+         A     15      GLY   H      7.8     0   
+         A     15      GLY   N      106.5   0   
+         A     15      GLY   QA     3.42    0.02
+         A     17      VAL   CG%    22.1    0.3 
+         A     17      VAL   HG%    0.73    0.02
+         A     18      PHE   H      8.3     0   
+         A     18      PHE   HB2    2.87    0.02
+         A     18      PHE   HB3    2.42    0.02
+         A     18      PHE   N      119.5   0   
+         A     19      LEU   CA     172.2   0   
+         A     19      LEU   CB     58.5    0   
+         A     19      LEU   CD1    22.2    0   
+         A     19      LEU   CD2    58.5    0   
+         A     19      LEU   CDX    17.4    0.3 
+         A     19      LEU   CDY    18.7    0.3 
+         A     19      LEU   CG     32.3    0   
+         A     19      LEU   HBX    2.13    0.02
+         A     19      LEU   HBY    2.51    0.02
+         A     19      LEU   HDX%   0.87    0.02
+         A     19      LEU   HDY%   0.73    0.02
+         A     19      LEU   HN     7.2     0   
+         A     19      LEU   N      119.5   0   
+         A     20      CYS   HBX    3.2     0   
+         A     21      ALA   H      8.33    0.02
+         A     21      ALA   HA     4.17    0.02
+         A     21      ALA   HB%    1.34    0.02
+         A     23      LYS   CA     43.2    0.25
+         A     23      LYS   H      8.45    0.04
+         A     23      LYS   HA     4.27    0.02
+         A     23      LYS   N      123.45  0.4 
+         A     24      ASP   HBY    3.4     0   
+         A     24B     GLN   H      8.3     0   
+         A     24B     GLN   N      119.5   0   
+         A     24C     GLN   C      28.3    0   
+         A     24C     GLN   CA     22.2    0   
+         A     24C     GLN   CB     58.5    0   
+         A     24C     GLN   CG     32.3    0   
+         A     24D     TYR   H      8.3     0   
+         A     24D     TYR   N      119.5   0   
+         X     @5      GLX   H      9.1     0   
+         X     @5      GLX   N      118.3   0   
+         @2    SS@12   .     CAi-1  48.2    0   
+         @2    SS@231  GLX?  CAi-1  48.2    0   
+      stop_
 
 # The atom_name by itself serves to distinguish between real atoms ('HA'),
 #  pseudoatoms ('QA'), sets of atoms ('HB%'), sterospecifically assigned atoms
@@ -305,9 +355,9 @@ save_nef_chemical_shift_list_1
 # Val 17 HG%/CG% show two methyl groups that overlap in both carbon and proton
 # dimensions.
 # 19 LEU HDX% is the methyl bound to CDX (and not to CDY).
-# The last two shifts (with chain_code @1) are unassigned but observed resonances,
+# The last two shifts (with chain_code @2) are unassigned but observed resonances,
 
-save_
+   save_
 
 
 #=======================================================================
@@ -325,65 +375,64 @@ save_nef_distance_restraint_list_L1
 
 
 # Mandatory parameters
-  _nef_distance_restraint_list.sf_category          nef_distance_restraint_list
-  _nef_distance_restraint_list.sf_framecode         nef_distance_restraint_list_L1
-
-  _nef_distance_restraint_list.potential_type       square-well-parabolic-linear
+      _nef_distance_restraint_list.sf_category     nef_distance_restraint_list
+      _nef_distance_restraint_list.sf_framecode    nef_distance_restraint_list_L1
+      _nef_distance_restraint_list.potential_type  square-well-parabolic-linear
   
-  # Optional parameter:
-  _nef_distance_restraint_list.restraint_origin     noe
-  # The restraint_origin describes the origin or source of the restraints. For
-  # distance restraints likely values would be 'noe', 'hbond', 'mutation', 'shift_perturbation' 
+      # Optional parameter:
+      _nef_distance_restraint_list.restraint_origin     noe
+      # The restraint_origin describes the origin or source of the restraints. For
+      # distance restraints likely values would be 'noe', 'hbond', 'mutation', 'shift_perturbation' 
 
-  loop_
-    # Mandatory parameters, except for restraint_combination_id
-    _nef_distance_restraint.ordinal
-    _nef_distance_restraint.restraint_id
-    _nef_distance_restraint.restraint_combination_id
-    _nef_distance_restraint.chain_code_1
-    _nef_distance_restraint.sequence_code_1
-    _nef_distance_restraint.residue_type_1
-    _nef_distance_restraint.atom_name_1
-    _nef_distance_restraint.chain_code_2
-    _nef_distance_restraint.sequence_code_2
-    _nef_distance_restraint.residue_type_2
-    _nef_distance_restraint.atom_name_2
-    _nef_distance_restraint.weight
+      loop_
+         # Mandatory parameters, except for restraint_combination_id
+         _nef_distance_restraint.ordinal
+         _nef_distance_restraint.restraint_id
+         _nef_distance_restraint.restraint_combination_id
+         _nef_distance_restraint.chain_code_1
+         _nef_distance_restraint.sequence_code_1
+         _nef_distance_restraint.residue_type_1
+         _nef_distance_restraint.atom_name_1
+         _nef_distance_restraint.chain_code_2
+         _nef_distance_restraint.sequence_code_2
+         _nef_distance_restraint.residue_type_2
+         _nef_distance_restraint.atom_name_2
+         _nef_distance_restraint.weight
 
-  # The following parameters are optional. target_value and target_value_uncertainty
-  # should be given whenever a meaningful value is known'
-  # Other parameters need be given only if they are defined for the potential_type
-    _nef_distance_restraint.target_value
-    _nef_distance_restraint.target_value_uncertainty
-    _nef_distance_restraint.lower_linear_limit
-    _nef_distance_restraint.lower_limit
-    _nef_distance_restraint.upper_limit
-    _nef_distance_restraint.upper_linear_limit
+         # The following parameters are optional. target_value and target_value_uncertainty
+         # should be given whenever a meaningful value is known'
+         # Other parameters need be given only if they are defined for the potential_type
+         _nef_distance_restraint.target_value
+         _nef_distance_restraint.target_value_uncertainty
+         _nef_distance_restraint.lower_linear_limit
+         _nef_distance_restraint.lower_limit
+         _nef_distance_restraint.upper_limit
+         _nef_distance_restraint.upper_linear_limit
+      
+         # key: ordinal
 
-  # key: ordinal
+         1  1  .  A  17  VAL  H    A  21  ALA  HB%   1  3.7  0.4  2    2.5  4.2  4.7
+         2  1  .  A  17  VAL  H    A  22  THR  HG2%  1  3.7  0.4  2    2.5  4.2  4.7
+         3  1  .  A  18  LEU  H    A  21  ALA  HB%   1  3.7  0.4  2    2.5  4.2  4.7
+         4  1  .  A  18  LEU  H    A  22  THR  HG2%  1  3.7  0.4  2    2.5  4.2  4.7
+         5  5  .  A  18  PHE  HB2  A  24  ASP  HBX   1  2.8  0.4  1.5  2    3.2  3.7
+         6  8  .  A  18  PHE  HB2  A  24  ASP  HBY   1  4.4  0.4  3.6  4.1  5.2  5.7
+         7  8  .  A  24  ASP  HBY  E  6B  SER  HB2   1  4.4  0.4  3.6  4.1  5.2  5.7
+      stop_
 
-    1  1  .   A 21   ALA  HB%  A 17  VAL  H   1.00 3.7  0.4   2.0  2.5  4.2  4.7
-    2  1  .   A 21   ALA  HB%  A 18  LEU  H   1.00 3.7  0.4   2.0  2.5  4.2  4.7
-    3  1  .   A 22   THR  HG2% A 17  VAL  H   1.00 3.7  0.4   2.0  2.5  4.2  4.7
-    4  1  .   A 22   THR  HG2% A 18  LEU  H   1.00 3.7  0.4   2.0  2.5  4.2  4.7
-    5  5  .   A 18   PHE  HB2  A 24  ASP  HBX 1.00 2.8  0.4   1.5  2.0  3.2  3.7
-    6  8  .   A 18   PHE  HB2  A 24  ASP  HBY 1.00 4.4  0.4   3.6  4.1  5.2  5.7
-    6  8  .   E 6B   SER  HB2  A 24  ASP  HBY 1.00 4.4  0.4   3.6  4.1  5.2  5.7
-  stop_
+      # The first column (ordinal) is a consecutive line number that does not persist  
+      # when data are re-exported
+      # The second column gives the restraint ID.
+      # Lines with the same restraint_id are combined into a single restraint
+      # (OR operations, effectively an ambiguous assignment).
+      # The restraint_combination_id is used for more complex logic,
+      # see dihedral restrains for an example.
 
-  # The first column (ordinal) is a consecutive line number that does not persist  
-  # when data are re-exported
-  # The second column gives the restraint ID.
-  # Lines with the same restraint_id are combined into a single restraint
-  # (OR operations, effectively an ambiguous assignment).
-  # The restraint_combination_id is used for more complex logic,
-  # see dihedral restrains for an example.
+      # Each line (sub-restraint) of the table has its own independent
+      # parameters (weight, target_value, upper_limit, etc.), which may be different
+      # within the same restraint.
 
-  # Each line (sub-restraint) of the table has its own independent
-  # parameters (weight, target_value, upper_limit, etc.), which may be different
-  # within the same restraint.
-
-save_
+   save_
 
 #============================================================================
 # Section 6
@@ -391,96 +440,92 @@ save_
 # Optional: Dihedral restraint list(s)
 #============================================================================
 
+   save_nef_dihedral_restraint_list_L2
 
-save_nef_dihedral_restraint_list_L2
+      # Mandatory parameters:
+      _nef_dihedral_restraint_list.sf_category     nef_dihedral_restraint_list
+      _nef_dihedral_restraint_list.sf_framecode    nef_dihedral_restraint_list_L2
+      _nef_dihedral_restraint_list.potential_type  square-well-parabolic
 
-# Mandatory parameters:
-  _nef_dihedral_restraint_list.sf_category          nef_dihedral_restraint_list
-  _nef_dihedral_restraint_list.sf_framecode         nef_dihedral_restraint_list_L2
+      # Optional parameter:
+      _nef_dihedral_restraint_list.restraint_origin     talos
+      # The restraint_origin describes the origin or source of the restraints. For
+      # distance restraints likely values would be 'chemical_shift', 'jcoupling'
 
-  _nef_dihedral_restraint_list.potential_type     	square-well-parabolic
+      loop_
+         # Mandatory parameters, except for restraint_combination_id
+         _nef_dihedral_restraint.ordinal
+         _nef_dihedral_restraint.restraint_id
+         _nef_dihedral_restraint.restraint_combination_id
+         _nef_dihedral_restraint.chain_code_1
+         _nef_dihedral_restraint.sequence_code_1
+         _nef_dihedral_restraint.residue_type_1
+         _nef_dihedral_restraint.atom_name_1
+         _nef_dihedral_restraint.chain_code_2
+         _nef_dihedral_restraint.sequence_code_2
+         _nef_dihedral_restraint.residue_type_2
+         _nef_dihedral_restraint.atom_name_2
+         _nef_dihedral_restraint.chain_code_3
+         _nef_dihedral_restraint.sequence_code_3
+         _nef_dihedral_restraint.residue_type_3
+         _nef_dihedral_restraint.atom_name_3
+         _nef_dihedral_restraint.chain_code_4
+         _nef_dihedral_restraint.sequence_code_4
+         _nef_dihedral_restraint.residue_type_4
+         _nef_dihedral_restraint.atom_name_4
+         _nef_dihedral_restraint.weight
 
-  # Optional parameter:
-  _nef_dihedral_restraint_list.restraint_origin     talos
-  # The restraint_origin describes the origin or source of the restraints. For
-  # distance restraints likely values would be 'chemical_shift', 'jcoupling'
+         # The following parameters are optional. target_value and target_value_uncertainty
+         # should be given whenever a meaningful value is known'
+         # Other parameters need be given only if they are defined for the potential_type
+         _nef_dihedral_restraint.target_value
+         _nef_dihedral_restraint.target_value_uncertainty
+         _nef_dihedral_restraint.lower_linear_limit
+         _nef_dihedral_restraint.lower_limit
+         _nef_dihedral_restraint.upper_limit
+         _nef_dihedral_restraint.upper_linear_limit
+         _nef_dihedral_restraint.name
+      
+         # key: ordinal
+         
+         1  1  .  A  21  ALA  N  A  21  ALA  CA  A  21  ALA  C   A  22  THR  N  1  -50  5  .  -60  -40  .  PSI
+         2  1  .  A  21  ALA  N  A  21  ALA  CA  A  21  ALA  C   A  22  THR  N  1  105  5  .   90  120  .  PSI
+         3  2  .  A  12  ALA  C  A  22  THR  N   A  22  THR  CA  A  22  THR  C  3  -50  8  .  -60  -40  .  .  
+         4  3  1  A  23  LYS  C  A  24  ASP  N   A  24  ASP  CA  A  24  ASP  C  1  -50  5  .  -60  -40  .  PHI
+         5  3  1  A  24  ASP  N  A  24  ASP  CA  A  24  ASP  C   A  25  HIS  N  1  -50  5  .  -60  -40  .  PSI
+         6  4  2  A  15  GLY  C  A  16  ASN  N   A  16  ASN  CA  A  16  ASN  C  1  -50  5  .  -60  -40  .  PHI
+         7  4  2  A  16  ASN  N  A  16  ASN  CA  A  16  ASN  C   A  17  CYS  N  1  -50  5  .  -60  -40  .  .  
+         8  4  3  A  15  GLY  C  A  16  ASN  N   A  16  ASN  CA  A  16  ASN  C  1  -80  5  .  -90  -70  .  PHI
+         9  4  3  A  16  ASN  N  A  16  ASN  CA  A  16  ASN  C   A  17  CYS  N  1  -80  5  .  -90  -70  .  .  
+      stop_
 
-  loop_
-    # Mandatory parameters, except for restraint_combination_id
-    _nef_dihedral_restraint.ordinal
-    _nef_dihedral_restraint.restraint_id
-    _nef_dihedral_restraint.restraint_combination_id
-    _nef_dihedral_restraint.chain_code_1
-    _nef_dihedral_restraint.sequence_code_1
-    _nef_dihedral_restraint.residue_type_1
-    _nef_dihedral_restraint.atom_name_1
-    _nef_dihedral_restraint.chain_code_2
-    _nef_dihedral_restraint.sequence_code_2
-    _nef_dihedral_restraint.residue_type_2
-    _nef_dihedral_restraint.atom_name_2
-    _nef_dihedral_restraint.chain_code_3
-    _nef_dihedral_restraint.sequence_code_3
-    _nef_dihedral_restraint.residue_type_3
-    _nef_dihedral_restraint.atom_name_3
-    _nef_dihedral_restraint.chain_code_4
-    _nef_dihedral_restraint.sequence_code_4
-    _nef_dihedral_restraint.residue_type_4
-    _nef_dihedral_restraint.atom_name_4
-    _nef_dihedral_restraint.weight
+      # - Restraint 1 is an ambiguous psi restraint. The atoms are the same,
+      #   but there are two allowed angle ranges in this case, so there are
+      #   two sub-restraints with different parameters on the two lines.
+      #
+      #   Restraint 2 is a normal phi restraint - note the different weight.
+      #
+      #   Restraint 3 is a combination of a phi and a psi restraint AND'ed
+      #   together. Normally this kind of restraint would rarely be used
+      #   - you would simply divide this into two separate restraints -
+      #   but it is put here to show how the restraint_combination_id works.
+      #
+      #   Restraint 4 defines two separate non-contiguous regions in the
+      #   Ramachandran plot, and shows how the restraint_combination_id
+      #   is used in practice. The logic of the restraint is :
+      #   (item1 AND item2) OR (item3 AND item4)
+      #
+      #   Subrestraints with the same restraint_combination_id
+      #   are AND'ed together, after which groups and individual
+      #   subrestraints within a given restraint are OR'ed as usual.
+      #   restraint_combination_id are unique across the entire table, so
+      #   you can select a set of AND'ed restraints by selecting all lines
+      #   with the same index in the combination_id column. Only
+      #   restraint items within the same restraint can be AND'ed together,
+      #   or, in other words, a given restraint_combination_id can only be
+      #   used within the same restraint.
 
-  # The following parameters are optional. target_value and target_value_uncertainty
-  # should be given whenever a meaningful value is known'
-  # Other parameters need be given only if they are defined for the potential_type
-    _nef_dihedral_restraint.target_value
-    _nef_dihedral_restraint.target_value_uncertainty
-    _nef_dihedral_restraint.lower_linear_limit
-    _nef_dihedral_restraint.lower_limit
-    _nef_dihedral_restraint.upper_limit
-    _nef_dihedral_restraint.upper_linear_limit
-    _nef_dihedral_restraint.name
-
-  # key: ordinal
-
-1  1  .  A 21 ALA N  A 21 ALA CA  A 21 ALA  C  A 22 THR N 1.00 -50.0 5.0 .  -60.0 -40.0  . PSI
-2  1  .  A 21 ALA N  A 21 ALA CA  A 21 ALA  C  A 22 THR N 1.00 105.0 5.0 .   90.0 120.0  . PSI
-3  2  .  A 12 ALA C  A 22 THR N   A 22 THR CA  A 22 THR C 3.00 -50.0 8.0 .  -60.0 -40.0  . PHI
-4  3  1  A 23 LYS C  A 24 ASP N   A 24 ASP CA  A 24 ASP C 1.00 -50.0 5.0 .  -60.0 -40.0  . PHI
-5  3  1  A 24 ASP N  A 24 ASP CA  A 24 ASP  C  A 25 HIS N 1.00 105.0 5.0 .   90.0 120.0  . PSI
-6  4  2  A 15 GLY C  A 16 ASN N   A 16 ASN CA  A 16 ASN C 1.00 -50.0 5.0 .  -60.0 -40.0  . PHI
-7  4  2  A 16 ASN N  A 16 ASN CA  A 16 ASN  C  A 17 CYS N 1.00 105.0 5.0 .   90.0 120.0  . PSI
-8  4  3  A 15 GLY C  A 16 ASN N   A 16 ASN CA  A 16 ASN C 1.00 -80.0 5.0 .  -90.0 -70.0  . PHI
-9  4  3  A 16 ASN N  A 16 ASN CA  A 16 ASN  C  A 17 CYS N 1.00 155.0 5.0 .  140.0 170.0  . PSI
-
-stop_
-
-  # - Restraint 1 is an ambiguous psi restraint. The atoms are the same,
-  #   but there are two allowed angle ranges in this case, so there are
-  #   two sub-restraints with different parameters on the two lines.
-  #
-  #   Restraint 2 is a normal phi restraint - note the different weight.
-  #
-  #   Restraint 3 is a combination of a phi and a psi restraint AND'ed
-  #   together. Normally this kind of restraint would rarely be used
-  #   - you would simply divide this into two separate restraints -
-  #   but it is put here to show how the restraint_combination_id works.
-  #
-  #   Restraint 4 defines two separate non-contiguous regions in the
-  #   Ramachandran plot, and shows how the restraint_combination_id
-  #   is used in practice. The logic of the restraint is :
-  #   (item1 AND item2) OR (item3 AND item4)
-  #
-  #   Subrestraints with the same restraint_combination_id
-  #   are AND'ed together, after which groups and individual
-  #   subrestraints within a given restraint are OR'ed as usual.
-  #   restraint_combination_id are unique across the entire table, so
-  #   you can select a set of AND'ed restraints by selecting all lines
-  #   with the same index in the combination_id column. Only
-  #   restraint items within the same restraint can be AND'ed together,
-  #   or, in other words, a given restraint_combination_id can only be
-  #   used within the same restraint.
-
-save_
-
+   save_
 
 #=======================================================================
 # Section 7
@@ -488,61 +533,58 @@ save_
 # Optional: RDC restraint list(s)
 #=======================================================================
 
-save_nef_rdc_restraint_list_1
+   save_nef_rdc_restraint_list_3
 
-# Mandatory parameters
-  _nef_rdc_restraint_list.sf_category           	nef_rdc_restraint_list
-  _nef_rdc_restraint_list.sf_framecode           	nef_rdc_restraint_list_1
-
-  _nef_rdc_restraint_list.potential_type            log-normal
+      # Mandatory parameters
+      _nef_rdc_restraint_list.sf_category           nef_rdc_restraint_list
+      _nef_rdc_restraint_list.sf_framecode          nef_rdc_restraint_list_3
+      _nef_rdc_restraint_list.potential_type        log-normal
   
-  # Optional parameter:
-  _nef_rdc_restraint_list.restraint_origin     measured
-  # The restraint_origin describes the origin or source of the restraints.
-  
-# Optional parameters
-   _nef_rdc_restraint_list.tensor_magnitude      11.0000  
-   _nef_rdc_restraint_list.tensor_rhombicity     0.0670
-   _nef_rdc_restraint_list.tensor_chain_code     C
-   _nef_rdc_restraint_list.tensor_sequence_code    900
-   _nef_rdc_restraint_list.tensor_residue_type     TNSR
+      # Optional parameters
+      _nef_rdc_restraint_list.restraint_origin     measured
+      # The restraint_origin describes the origin or source of the restraints.
+      _nef_rdc_restraint_list.tensor_magnitude      11 
+      _nef_rdc_restraint_list.tensor_rhombicity     0.067
+      _nef_rdc_restraint_list.tensor_chain_code     C
+      _nef_rdc_restraint_list.tensor_sequence_code  900
+      _nef_rdc_restraint_list.tensor_residue_type   TNSR
 
-  loop_
-    # Mandatory parameters, except for restraint_combination_id
-      _nef_rdc_restraint.ordinal
-      _nef_rdc_restraint.restraint_id
-      _nef_rdc_restraint.restraint_combination_id
-      _nef_rdc_restraint.chain_code_1
-      _nef_rdc_restraint.sequence_code_1
-      _nef_rdc_restraint.residue_type_1
-      _nef_rdc_restraint.atom_name_1
-      _nef_rdc_restraint.chain_code_2
-      _nef_rdc_restraint.sequence_code_2
-      _nef_rdc_restraint.residue_type_2
-      _nef_rdc_restraint.atom_name_2
-      _nef_rdc_restraint.weight
+      loop_
+         # Mandatory parameters, except for restraint_combination_id
+         _nef_rdc_restraint.ordinal
+         _nef_rdc_restraint.restraint_id
+         _nef_rdc_restraint.restraint_combination_id
+         _nef_rdc_restraint.chain_code_1
+         _nef_rdc_restraint.sequence_code_1
+         _nef_rdc_restraint.residue_type_1
+         _nef_rdc_restraint.atom_name_1
+         _nef_rdc_restraint.chain_code_2
+         _nef_rdc_restraint.sequence_code_2
+         _nef_rdc_restraint.residue_type_2
+         _nef_rdc_restraint.atom_name_2
+         _nef_rdc_restraint.weight
 
-  # The following parameters are optional. target_value and target_value_uncertainty
-  # should be given whenever a meaningful value is known'
-  # Other parameters need be given only if they are defined for the potential_type
-    _nef_rdc_restraint.target_value
-    _nef_rdc_restraint.target_value_uncertainty
+         # The following parameters are optional. target_value and target_value_uncertainty
+         # should be given whenever a meaningful value is known'
+         # Other parameters need be given only if they are defined for the potential_type
+         _nef_rdc_restraint.target_value
+         _nef_rdc_restraint.target_value_uncertainty
 
-  # Optional parameters - use only the ones needed for the potential:
-   _nef_rdc_restraint.lower_linear_limit
-   _nef_rdc_restraint.lower_limit
-   _nef_rdc_restraint.upper_limit
-   _nef_rdc_restraint.upper_linear_limit
-    _nef_rdc_restraint.scale
-    _nef_rdc_restraint.distance_dependent
+         # Optional parameters - use only the ones needed for the potential:
+         _nef_rdc_restraint.lower_linear_limit
+         _nef_rdc_restraint.lower_limit
+         _nef_rdc_restraint.upper_limit
+         _nef_rdc_restraint.upper_linear_limit
+         _nef_rdc_restraint.scale
+         _nef_rdc_restraint.distance_dependent
 
-  # key: ordinal
+         # key: ordinal
 
-    1  1 .  A  21  ALA  H  A  21  ALA  N  1.00 -5.2  0.33  .  .  .  .  1.0  false
-    2  2 .  A  22  THR  H  A  22  THR  N  1.00  3.1  0.40  .  .  .  .  1.0  false
-  stop_
+         1  1  .  A  21  ALA  H  A  21  ALA  N  1  -5.2  0.33  .  .  .  .  1  false
+         2  2  .  A  22  THR  H  A  22  THR  N  1  3.1   0.4   .  .  .  .  1  false
+      stop_
 
-save_
+   save_
 
 
 
@@ -553,314 +595,308 @@ save_
 #=======================================================================
 
 
-save_nef_nmr_spectrum_cnoesy1
+   save_nef_nmr_spectrum_cnoesy1
 
-# Mandatory parameters
-  _nef_nmr_spectrum.sf_category           		nef_nmr_spectrum
-  _nef_nmr_spectrum.sf_framecode              nef_nmr_spectrum_cnoesy1
+      # Mandatory parameters
+      _nef_nmr_spectrum.sf_category                nef_nmr_spectrum
+      _nef_nmr_spectrum.sf_framecode               nef_nmr_spectrum_cnoesy1
 
-  _nef_nmr_spectrum.num_dimensions        		3
-  _nef_nmr_spectrum.chemical_shift_list       nef_chemical_shift_list_1
+      _nef_nmr_spectrum.num_dimensions             3
+      _nef_nmr_spectrum.chemical_shift_list        nef_chemical_shift_list_1
   
-  # optional parameters
-  _nef_nmr_spectrum.experiment_classification   	H_H[N].through-space
-  _nef_nmr_spectrum.experiment_type             	15N-NOESY-HSQC
+      # optional parameters
+      _nef_nmr_spectrum.experiment_classification  H_H[N].through-space
+      _nef_nmr_spectrum.experiment_type            '15N NOESY-HSQC'
+      # The chemical_shift_list gives the saveframe id within the project for the saveframe
+      # that contains the relevant chemical shift list.
 
-  # The chemical_shift_list gives the saveframe id within the project for the saveframe
-  # that contains the relevant chemical shift list.
+      # The experiment_classification uses the CCPN convention
+      # See http://link.springer.com/article/10.1007%2Fs10858-006-9076-z
+      #
+      # The experiment_type is freely settable by the user / program.
 
-  # The experiment_classification uses the CCPN convention
-  # See http://link.springer.com/article/10.1007%2Fs10858-006-9076-z
-  #
-  # The experiment_type is freely settable by the user/ program.
-
-  loop_
+      loop_
 
       # mandatory parameters
-      _nef_spectrum_dimension.dimension_id
-      _nef_spectrum_dimension.axis_unit
-      _nef_spectrum_dimension.axis_code
+         _nef_spectrum_dimension.dimension_id
+         _nef_spectrum_dimension.axis_unit
+         _nef_spectrum_dimension.axis_code
       
       # optional parameters
-      _nef_spectrum_dimension.spectrometer_frequency
-      _nef_spectrum_dimension.spectral_width
-      _nef_spectrum_dimension.value_first_point
-      _nef_spectrum_dimension.folding
-      _nef_spectrum_dimension.absolute_peak_positions
-      _nef_spectrum_dimension.is_acquisition
+         _nef_spectrum_dimension.spectrometer_frequency
+         _nef_spectrum_dimension.spectral_width
+         _nef_spectrum_dimension.value_first_point
+         _nef_spectrum_dimension.folding
+         _nef_spectrum_dimension.absolute_peak_positions
+         _nef_spectrum_dimension.is_acquisition
 
   # key: dimension_id
 
-      1  ppm  1H   500.139  10.4    9.9	circular  true    false
-      2  ppm 15N    98.37   30.7  127.0	circular  true    false
-      3  ppm  1H   500.139  14.2   11.8	none	    true    true
-  stop_
+         1  ppm  1H   500.139  10.4  9.9   circular  true  false
+         2  ppm  15N  98.37    30.7  127   circular  true  false
+         3  ppm  1H   500.139  14.2  11.8  none      true  true 
+      stop_
 
-# dimension_id, axis_unit, and axis_code are mandatory.
+      # dimension_id, axis_unit, and axis_code are mandatory.
 
-# - axis_unit could be 'Hz' 'ppm', 'point', 's', ...
-# - axis_code is the isotope (in the form '1H', '13C', ...) for shifts,
-#   e.g. 'delay' for a T1 time axis. More complicated versions will be
-#   needed for J-coupling, multiple-quantum and other non-shift axes.
-# - Spectrometer frequency is in MHz
-# - spectral_width  is the acquisition SW, that is used for folding, in units of
-#   axis_unit
-#   Similarly, value_first_point is the value for point 1 in the spectrum after
-#   Fourier transformation, i..e *before* then removal of any points.
-# - folding can be either 'mirror' (seq. quadrature),
-#   'circular' (std. aliasing, for sim. quadrature), or 'none'
-# - absolute_peak_positions determines if peak positions are correct or may be
-#   folded/aliased.
-#   If 'false' all peaks are given in the acquisition window, whether this is
-#   their correct position or not.
-#   If 'true' peaks are given at their correct position, whether this is
-#   in the acquisition window or not.
-# - is_acquisition  Is this the acquisition dimension?
-#
-# Strictly speaking, 'folding' and 'spectral_width' are only necessary if
-# 'absolute_peak_positions' is false, and 'value_first_point' is only necessary
-# if folding also is 'mirror'.
-# It is still recommended to put in all parameters where known.
+      # - axis_unit could be 'Hz' 'ppm', 'point', 's', ...
+      # - axis_code is the isotope (in the form '1H', '13C', ...) for shifts,
+      #   e.g. 'delay' for a T1 time axis. More complicated versions will be
+      #   needed for J-coupling, multiple-quantum and other non-shift axes.
+      # - Spectrometer frequency is in MHz
+      # - spectral_width  is the acquisition SW, that is used for folding, in units of
+      #   axis_unit
+      #   Similarly, value_first_point is the value for point 1 in the spectrum after
+      #   Fourier transformation, i..e *before* then removal of any points.
+      # - folding can be either 'mirror' (seq. quadrature),
+      #   'circular' (std. aliasing, for sim. quadrature), or 'none'
+      # - absolute_peak_positions determines if peak positions are correct or may be
+      #   folded/aliased.
+      #   If 'false' all peaks are given in the acquisition window, whether this is
+      #   their correct position or not.
+      #   If 'true' peaks are given at their correct position, whether this is
+      #   in the acquisition window or not.
+      # - is_acquisition  Is this the acquisition dimension?
+      #
+      # Strictly speaking, 'folding' and 'spectral_width' are only necessary if
+      # 'absolute_peak_positions' is false, and 'value_first_point' is only necessary
+      # if folding also is 'mirror'.
+      # It is still recommended to put in all parameters where known.
 
-# Mandatory loop.
+      # Mandatory loop.
 
-  loop_
-      # mandatory parameters
-      _nef_spectrum_dimension_transfer.dimension_1
-      _nef_spectrum_dimension_transfer.dimension_2
-      _nef_spectrum_dimension_transfer.transfer_type
+      loop_
+         # mandatory parameters
+         _nef_spectrum_dimension_transfer.dimension_1
+         _nef_spectrum_dimension_transfer.dimension_2
+         _nef_spectrum_dimension_transfer.transfer_type
       
-      # optional parameter
-      _nef_spectrum_dimension_transfer.is_indirect
+         # optional parameter
+         _nef_spectrum_dimension_transfer.is_indirect
 
-  # key: dimension_1, dimension_2
+         # key: dimension_1, dimension_2
 
-      1 3 through-space  false
-      2 3 onebond        false
-  stop_
+         1  3  through-space  false
+         2  3  onebond        false
+      stop_
 
-# For peak lists with different dimensionality tags are added and removed to fit.
-# The example here is for a 3D peak list
-#
-# Dimensions are given in the order of the _nef_Spectrum.dimension_id defined above.
+      # For peak lists with different dimensionality tags are added and removed to fit.
+      # The example here is for a 3D peak list
+      #
+      # Dimensions are given in the order of the _nef_Spectrum.dimension_id defined above.
 
-  loop_
+      loop_
+         _nef_peak.ordinal
+         _nef_peak.peak_id
+         _nef_peak.volume
+         _nef_peak.volume_uncertainty
+         _nef_peak.height
+         _nef_peak.height_uncertainty
+         _nef_peak.position_1
+         _nef_peak.position_uncertainty_1
+         _nef_peak.position_2
+         _nef_peak.position_uncertainty_2
+         _nef_peak.position_3
+         _nef_peak.position_uncertainty_3
+         _nef_peak.chain_code_1
+         _nef_peak.sequence_code_1
+         _nef_peak.residue_type_1
+         _nef_peak.atom_name_1
+         _nef_peak.chain_code_2
+         _nef_peak.sequence_code_2
+         _nef_peak.residue_type_2
+         _nef_peak.atom_name_2
+         _nef_peak.chain_code_3
+         _nef_peak.sequence_code_3
+         _nef_peak.residue_type_3
+         _nef_peak.atom_name_3
 
-      _nef_peak.ordinal
-      _nef_peak.peak_id
-      _nef_peak.volume
-      _nef_peak.volume_uncertainty
-      _nef_peak.height
-      _nef_peak.height_uncertainty
-      _nef_peak.position_1
-      _nef_peak.position_uncertainty_1
-      _nef_peak.position_2
-      _nef_peak.position_uncertainty_2
-      _nef_peak.position_3
-      _nef_peak.position_uncertainty_3
-      _nef_peak.chain_code_1
-      _nef_peak.sequence_code_1
-      _nef_peak.residue_type_1
-      _nef_peak.atom_name_1
-      _nef_peak.chain_code_2
-      _nef_peak.sequence_code_2
-      _nef_peak.residue_type_2
-      _nef_peak.atom_name_2
-      _nef_peak.chain_code_3
-      _nef_peak.sequence_code_3
-      _nef_peak.residue_type_3
-      _nef_peak.atom_name_3
+         # key: ordinal
 
- # key: ordinal
+         1   1  73000000  5100000   33000000  1100000   3.2  0.05  119.5  0.5  8.3  0.03  A  14  TRP  HB3  A  18    PHE  N    A  18    PHE  H  
+         2   1  73000000  5100000   33000000  1100000   3.2  0.05  119.5  0.5  8.3  0.03  A  19  LEU  HBY  A  24B   GLN  N    A  24B   GLN  H  
+         3   1  73000000  5100000   33000000  1100000   3.2  0.05  119.5  0.5  8.3  0.03  A  19  LEU  HBY  A  24D   TYR  N    A  24D   TYR  H  
+         4   1  73000000  5100000   33000000  1100000   3.2  0.05  119.5  0.5  8.3  0.03  A  20  CYS  HBX  A  24B   GLN  N    A  24B   GLN  H  
+         5   1  73000000  5100000   33000000  1100000   3.2  0.05  119.5  0.5  8.3  0.03  A  20  CYS  HBX  A  24D   TYR  N    A  24D   TYR  H  
+         6   3  54000000  7300000   34000000  5300000   4.4  0.05  106.5  0.5  7.8  0.03  .  .   .    .    A  15    GLY  N    A  15    GLY  H  
+         7   4  88000000  13000000  48000000  3300000   3.2  0.05  135.6  0.5  9.9  0.03  A  14  TRP  HB3  A  14    TRP  NE1  A  14    TRP  HE1
+         8   5  88000000  13000000  58000000  23000000  3.4  0.05  135.6  0.5  9.9  0.03  A  14  TRP  HB2  A  14    TRP  NE1  A  14    TRP  HE1
+         9   5  88000000  13000000  58000000  23000000  3.4  0.05  135.6  0.5  9.9  0.03  A  24  ASP  HBY  A  14    TRP  NE1  A  14    TRP  HE1
+         10  7  59000000  7100000   29000000  6100000   1.7  0.05  118.3  0.5  9.1  0.03  .  .   .    .    X  @5    GLX  N    X  @5    GLX  H  
+      stop_
 
- 1  1 7.3E7 5.1E6 3.3E7 1.1E6  3.2 0.05 119.5 0.5 8.3 0.03 A 19 LEU HBY A 17 GLN N   A 17 GLN H
- 2  1 7.3E7 5.1E6 3.3E7 1.1E6  3.2 0.05 119.5 0.5 8.3 0.03 A 20 CYS HBX A 17 GLN N   A 17 GLN H
- 3  1 7.3E7 5.1E6 3.3E7 1.1E6  3.2 0.05 119.5 0.5 8.3 0.03 A 19 LEU HBY A 19 TYR N   A 19 TYR H
- 4  1 7.3E7 5.1E6 3.3E7 1.1E6  3.2 0.05 119.5 0.5 8.3 0.03 A 20 CYS HBX A 19 TYR N   A 19 TYR H
- 5  1 7.3E7 5.1E6 3.3E7 1.1E6  3.2 0.05 119.5 0.5 8.3 0.03 A 14 TRP HB3 A 18 PHE N   A 18 PHE H
- 6  3 5.4E7 7.3E6 3.4E7 5.3E6  4.4 0.05 106.5 0.5 7.8 0.03 .  .   .   . A 15 GLY N   A 15 GLY H
- 7  4 8.8E7 1.3E7 4.8E7 3.3E6  3.2 0.05 135.6 0.5 9.9 0.03 A 14 TRP HB3 A 14 TRP NE1 A 14 TRP HE1
- 8  5 8.8E7 1.3E7 5.8E7 2.3E7  3.4 0.05 135.6 0.5 9.9 0.03 A 14 TRP HB2 A 14 TRP NE1 A 14 TRP HE1
- 9  5 8.8E7 1.3E7 5.8E7 2.3E7  3.4 0.05 135.6 0.5 9.9 0.03 A 24 ASP HBY A 14 TRP NE1 A 14 TRP HE1
-10  7 5.9E7 7.1E6 2.9E7 6.1E6  1.7 0.05 118.3 0.5 9.1 0.03 E 6B SER   . X @5 GLX N   X @5 GLX H
-  stop_
+      # Peaks 1 and 5 have ambiguous assignments.
 
-# Peaks 1 and 5 have ambiguous assignments.
+      # The frequency for A 14 Trp NE1 at 135.6 is likely outside the
+      # acquisition window. Since absolute_peak_positions is true for this dimension,
+      # the peak is given at the correct resonance frequency, rather than at
+      # the apparent position within the acquisition window.
 
-# The frequency for A 14 Trp NE1 at 135.6 is likely outside the
-# acquisition window. Since absolute_peak_positions is true for this dimension,
-# the peak is given at the correct resonance frequency, rather than at
-# the apparent position within the acquisition window.
+      # Volumes and peak position information are duplicated on each line belonging to
+      # a peak
+      # All such values must be identical, and written out as such. Programs may or
+      # may not check for errors when reading.
 
-# Volumes and peak position information are duplicated on each line belonging to
-# a peak
-# All such values must be identical, and written out as such. Programs may or
-# may not check for errors when reading.
-
-save_
+   save_
 
 
-save_nef_nmr_spectrum_dummy15d
+   save_nef_nmr_spectrum_dummy15d
 
-# Mandatory parameters
-  _nef_nmr_spectrum.sf_category               nef_nmr_spectrum
-  _nef_nmr_spectrum.sf_framecode              nef_nmr_spectrum_dummy15d
+      # Mandatory parameters
+      _nef_nmr_spectrum.sf_category          nef_nmr_spectrum
+      _nef_nmr_spectrum.sf_framecode         nef_nmr_spectrum_dummy15d
 
-  _nef_nmr_spectrum.num_dimensions            15
-  _nef_nmr_spectrum.chemical_shift_list       nef_chemical_shift_list_1
+      _nef_nmr_spectrum.num_dimensions       15
+      _nef_nmr_spectrum.chemical_shift_list  nef_chemical_shift_list_1
   
-  # optional parameters
-  _nef_nmr_spectrum.experiment_classification     .
-  _nef_nmr_spectrum.experiment_type               .
-
-  loop_
-      
-      # mandatory parameters
-      _nef_spectrum_dimension.dimension_id
-      _nef_spectrum_dimension.axis_unit
-      _nef_spectrum_dimension.axis_code
-      
       # optional parameters
-      _nef_spectrum_dimension.spectrometer_frequency
-      _nef_spectrum_dimension.spectral_width
-      _nef_spectrum_dimension.value_first_point
-      _nef_spectrum_dimension.folding
-      _nef_spectrum_dimension.absolute_peak_positions
-      _nef_spectrum_dimension.is_acquisition
+      _nef_nmr_spectrum.experiment_classification  .
+      _nef_nmr_spectrum.experiment_type      HNCCCCCCCCCCCCC
+
+      loop_
       
-  # key: dimension_id
-
-      1  ppm  1H   500.139  10.4    9.9 circular  true    false
-      2  ppm 15N    98.37   30.7  127.0 circular  true    false
-      3  ppm 13C      .       .      .  .         .       .
-      4  ppm 13C      .       .      .  .         .       .
-      5  ppm 13C      .       .      .  .         .       .
-      6  ppm 13C      .       .      .  .         .       .
-      7  ppm 13C      .       .      .  .         .       .
-      8  ppm 13C      .       .      .  .         .       .
-      9  ppm 13C      .       .      .  .         .       .
-     10  ppm 13C      .       .      .  .         .       .
-     11  ppm 13C      .       .      .  .         .       .
-     12  ppm 13C      .       .      .  .         .       .
-     13  ppm 13C      .       .      .  .         .       .
-     14  ppm 13C      .       .      .  .         .       .
-     15  ppm 13C      .       .      .  .         .       .
-  stop_
-
-
-# Peak lists can in theory be up to 15D
-# No spectra are 15D, of course, but some automatic assignment programs
-# can produce data as 15D peak lists. This is unlikely ever to matter in practice,
-# but the relevant loop tags are defined up to 15D - you just skip the ones you do not want.
-# and ignore spectra of too high dimensionality
-
-  loop_
-
-      _nef_peak.ordinal
-      _nef_peak.peak_id
-      _nef_peak.volume
-      _nef_peak.volume_uncertainty
-      _nef_peak.height
-      _nef_peak.height_uncertainty
-      _nef_peak.position_1
-      _nef_peak.position_uncertainty_1
-      _nef_peak.position_2
-      _nef_peak.position_uncertainty_2
-      _nef_peak.position_3
-      _nef_peak.position_uncertainty_3
-      _nef_peak.position_4
-      _nef_peak.position_uncertainty_4
-      _nef_peak.position_5
-      _nef_peak.position_uncertainty_5
-      _nef_peak.position_6
-      _nef_peak.position_uncertainty_6
-      _nef_peak.position_7
-      _nef_peak.position_uncertainty_7
-      _nef_peak.position_8
-      _nef_peak.position_uncertainty_8
-      _nef_peak.position_9
-      _nef_peak.position_uncertainty_9
-      _nef_peak.position_10
-      _nef_peak.position_uncertainty_10
-      _nef_peak.position_11
-      _nef_peak.position_uncertainty_11
-      _nef_peak.position_12
-      _nef_peak.position_uncertainty_12
-      _nef_peak.position_13
-      _nef_peak.position_uncertainty_13
-      _nef_peak.position_14
-      _nef_peak.position_uncertainty_14
-      _nef_peak.position_15
-      _nef_peak.position_uncertainty_15
-      _nef_peak.chain_code_1
-      _nef_peak.sequence_code_1
-      _nef_peak.residue_type_1
-      _nef_peak.atom_name_1
-      _nef_peak.chain_code_2
-      _nef_peak.sequence_code_2
-      _nef_peak.residue_type_2
-      _nef_peak.atom_name_2
-      _nef_peak.chain_code_3
-      _nef_peak.sequence_code_3
-      _nef_peak.residue_type_3
-      _nef_peak.atom_name_3
-      _nef_peak.chain_code_4
-      _nef_peak.sequence_code_4
-      _nef_peak.residue_type_4
-      _nef_peak.atom_name_4
-      _nef_peak.chain_code_5
-      _nef_peak.sequence_code_5
-      _nef_peak.residue_type_5
-      _nef_peak.atom_name_5
-      _nef_peak.chain_code_6
-      _nef_peak.sequence_code_6
-      _nef_peak.residue_type_6
-      _nef_peak.atom_name_6
-      _nef_peak.chain_code_7
-      _nef_peak.sequence_code_7
-      _nef_peak.residue_type_7
-      _nef_peak.atom_name_7
-      _nef_peak.chain_code_8
-      _nef_peak.sequence_code_8
-      _nef_peak.residue_type_8
-      _nef_peak.atom_name_8
-      _nef_peak.chain_code_9
-      _nef_peak.sequence_code_9
-      _nef_peak.residue_type_9
-      _nef_peak.atom_name_9
-      _nef_peak.chain_code_10
-      _nef_peak.sequence_code_10
-      _nef_peak.residue_type_10
-      _nef_peak.atom_name_10
-      _nef_peak.chain_code_11
-      _nef_peak.sequence_code_11
-      _nef_peak.residue_type_11
-      _nef_peak.atom_name_11
-      _nef_peak.chain_code_12
-      _nef_peak.sequence_code_12
-      _nef_peak.residue_type_12
-      _nef_peak.atom_name_12
-      _nef_peak.chain_code_13
-      _nef_peak.sequence_code_13
-      _nef_peak.residue_type_13
-      _nef_peak.atom_name_13
-      _nef_peak.chain_code_14
-      _nef_peak.sequence_code_14
-      _nef_peak.residue_type_14
-      _nef_peak.atom_name_14
-      _nef_peak.chain_code_15
-      _nef_peak.sequence_code_15
-      _nef_peak.residue_type_15
-      _nef_peak.atom_name_15
+         # mandatory parameters
+         _nef_spectrum_dimension.dimension_id
+         _nef_spectrum_dimension.axis_unit
+         _nef_spectrum_dimension.axis_code
       
- # key: ordinal
+         # optional parameters
+         _nef_spectrum_dimension.spectrometer_frequency
+         _nef_spectrum_dimension.spectral_width
+         _nef_spectrum_dimension.value_first_point
+         _nef_spectrum_dimension.folding
+         _nef_spectrum_dimension.absolute_peak_positions
+         _nef_spectrum_dimension.is_acquisition
+      
+         # key: dimension_id
 
- 1  1 7.3E7 5.1E6 3.3E7 1.1E6  
- 7.2 0.05 119.5 0.4 28.3 0.3 172.2 0.5 58.5 0.4 32.3 0.4 22.2 0.5 58.5 0.4 32.3 0.4 22.2 0.5 58.5 0.4 32.3 0.4 22.2 0.5 58.5 0.4 32.3 0.4  
- A 19 LEU HN A 19 LEU N A 18 GLN C  A 19 LEU CA A 19 LEU CB A 19 LEU CG  A 19 LEU CD1 A 19 LEU CD2 A 19 LEU CG A 19 LEU CA A 19 LEU CB A 19 LEU CG A 18 GLN CA A 18 GLN CB A 18 GLN CG 
-  stop_
+         1  ppm  1H   500.139  10.4    9.9 circular  true    false
+         2  ppm 15N    98.37   30.7  127.0 circular  true    false
+         3  ppm 13C      .       .      .  .         .       .
+         4  ppm 13C      .       .      .  .         .       .
+         5  ppm 13C      .       .      .  .         .       .
+         6  ppm 13C      .       .      .  .         .       .
+         7  ppm 13C      .       .      .  .         .       .
+         8  ppm 13C      .       .      .  .         .       .
+         9  ppm 13C      .       .      .  .         .       .
+        10  ppm 13C      .       .      .  .         .       .
+        11  ppm 13C      .       .      .  .         .       .
+        12  ppm 13C      .       .      .  .         .       .
+        13  ppm 13C      .       .      .  .         .       .
+        14  ppm 13C      .       .      .  .         .       .
+        15  ppm 13C      .       .      .  .         .       .
+      stop_
 
-save_
+
+      # Peak lists can in theory be up to 15D
+      # No spectra are 15D, of course, but some automatic assignment programs
+      # can produce data as 15D peak lists. This is unlikely ever to matter in practice,
+      # but the relevant loop tags are defined up to 15D - you just skip the ones you do not want.
+      # and ignore spectra of too high dimensionality
+
+      loop_
+         _nef_peak.ordinal
+         _nef_peak.peak_id
+         _nef_peak.volume
+         _nef_peak.volume_uncertainty
+         _nef_peak.height
+         _nef_peak.height_uncertainty
+         _nef_peak.position_1
+         _nef_peak.position_uncertainty_1
+         _nef_peak.position_2
+         _nef_peak.position_uncertainty_2
+         _nef_peak.position_3
+         _nef_peak.position_uncertainty_3
+         _nef_peak.position_4
+         _nef_peak.position_uncertainty_4
+         _nef_peak.position_5
+         _nef_peak.position_uncertainty_5
+         _nef_peak.position_6
+         _nef_peak.position_uncertainty_6
+         _nef_peak.position_7
+         _nef_peak.position_uncertainty_7
+         _nef_peak.position_8
+         _nef_peak.position_uncertainty_8
+         _nef_peak.position_9
+         _nef_peak.position_uncertainty_9
+         _nef_peak.position_10
+         _nef_peak.position_uncertainty_10
+         _nef_peak.position_11
+         _nef_peak.position_uncertainty_11
+         _nef_peak.position_12
+         _nef_peak.position_uncertainty_12
+         _nef_peak.position_13
+         _nef_peak.position_uncertainty_13
+         _nef_peak.position_14
+         _nef_peak.position_uncertainty_14
+         _nef_peak.position_15
+         _nef_peak.position_uncertainty_15
+         _nef_peak.chain_code_1
+         _nef_peak.sequence_code_1
+         _nef_peak.residue_type_1
+         _nef_peak.atom_name_1
+         _nef_peak.chain_code_2
+         _nef_peak.sequence_code_2
+         _nef_peak.residue_type_2
+         _nef_peak.atom_name_2
+         _nef_peak.chain_code_3
+         _nef_peak.sequence_code_3
+         _nef_peak.residue_type_3
+         _nef_peak.atom_name_3
+         _nef_peak.chain_code_4
+         _nef_peak.sequence_code_4
+         _nef_peak.residue_type_4
+         _nef_peak.atom_name_4
+         _nef_peak.chain_code_5
+         _nef_peak.sequence_code_5
+         _nef_peak.residue_type_5
+         _nef_peak.atom_name_5
+         _nef_peak.chain_code_6
+         _nef_peak.sequence_code_6
+         _nef_peak.residue_type_6
+         _nef_peak.atom_name_6
+         _nef_peak.chain_code_7
+         _nef_peak.sequence_code_7
+         _nef_peak.residue_type_7
+         _nef_peak.atom_name_7
+         _nef_peak.chain_code_8
+         _nef_peak.sequence_code_8
+         _nef_peak.residue_type_8
+         _nef_peak.atom_name_8
+         _nef_peak.chain_code_9
+         _nef_peak.sequence_code_9
+         _nef_peak.residue_type_9
+         _nef_peak.atom_name_9
+         _nef_peak.chain_code_10
+         _nef_peak.sequence_code_10
+         _nef_peak.residue_type_10
+         _nef_peak.atom_name_10
+         _nef_peak.chain_code_11
+         _nef_peak.sequence_code_11
+         _nef_peak.residue_type_11
+         _nef_peak.atom_name_11
+         _nef_peak.chain_code_12
+         _nef_peak.sequence_code_12
+         _nef_peak.residue_type_12
+         _nef_peak.atom_name_12
+         _nef_peak.chain_code_13
+         _nef_peak.sequence_code_13
+         _nef_peak.residue_type_13
+         _nef_peak.atom_name_13
+         _nef_peak.chain_code_14
+         _nef_peak.sequence_code_14
+         _nef_peak.residue_type_14
+         _nef_peak.atom_name_14
+         _nef_peak.chain_code_15
+         _nef_peak.sequence_code_15
+         _nef_peak.residue_type_15
+         _nef_peak.atom_name_15
+      
+         # key: ordinal
+
+         1  1  73000000  5100000  33000000  1100000  7.2  0.05  119.5  0.4  28.3  0.3  172.2  0.5  58.5  0.4  32.3  0.4  22.2  0.5  58.5  0.4  32.3  0.4  22.2  0.5  58.5  0.4  32.3  0.4  22.2  0.5  58.5  0.4  32.3  0.4  A  19  LEU  HN  A  19  LEU  N  A  24C   GLN  C  A  19  LEU  CA  A  19  LEU  CB  A  19  LEU  CG  A  19  LEU  CD1  A  19  LEU  CD2  A  19  LEU  CG  A  19  LEU  CA  A  19  LEU  CB  A  19  LEU  CG  A  24C   GLN  CA  A  24C   GLN  CB  A  24C   GLN  CG
+      stop_
+   save_
 
 
 #=======================================================================
@@ -872,31 +908,35 @@ save_
 #
 #=======================================================================
 
-save_nef_peak_restraint_links
+   save_nef_peak_restraint_links
 
-# Mandatory parameters
-  _nef_peak_restraint_links.sf_category           		nef_peak_restraint_links
-  _nef_peak_restraint_links.sf_framecode           		nef_peak_restraint_links
+      # Mandatory parameters
+      _nef_peak_restraint_links.sf_category           		nef_peak_restraint_links
+      _nef_peak_restraint_links.sf_framecode           		nef_peak_restraint_links
+      
+      # The loop is optional
+      # All tags within the loop are mandatory
 
-loop_
-  _nef_peak_restraint_link.nmr_spectrum_id
-  _nef_peak_restraint_link.peak_id
-  _nef_peak_restraint_link.restraint_list_id
-  _nef_peak_restraint_link.restraint_id
+      loop_
+         _nef_peak_restraint_link.nmr_spectrum_id
+         _nef_peak_restraint_link.peak_id
+         _nef_peak_restraint_link.restraint_list_id
+         _nef_peak_restraint_link.restraint_id
   
-  # key: nmr_spectrum_id, peak_id, restraint_list_id, restraint_id
+         # key: nmr_spectrum_id, peak_id, restraint_list_id, restraint_id
   
-  nef_nmr_spectrum_cnoesy1     1   nef_distance_restraint_list_L1     73
-  nef_nmr_spectrum_cnoesy1     1   nef_distance_restraint_list_L1    233
-  nef_nmr_spectrum_cnoesy1   577   nef_distance_restraint_list_L2     12
-  nef_nmr_spectrum_cnoesy1   316   nef_distance_restraint_list_L4   2755
+         nef_nmr_spectrum_cnoesy1     1   nef_distance_restraint_list_L1      5
+         nef_nmr_spectrum_cnoesy1     1   nef_distance_restraint_list_L1      8
+         nef_nmr_spectrum_cnoesy1     3   nef_dihedral_restraint_list_L2      4
+         nef_nmr_spectrum_cnoesy1     5   nef_dihedral_restraint_list_L2      4
+      stop_
 
-stop_
+      # The table gives links between peaks (in any spectrum) and restraints
+      # (in any restraint list of any type).
+      # There can be multiple restraint per peak, and vice versa.
+      #
+      # The links do not make scientific sense, but they are formally correct
 
-# The table gives links between peaks (in any spectrum) and restraints
-# (in any restraint list of any type).
-# There can be multiple restraint per peak, and vice versa.
-#
-# Commented-out lines refer to spectra that have been omited in this example
-# file.
 save_
+
+# End of data_nef_my_nmr_project_1

--- a/specification/Overview.md
+++ b/specification/Overview.md
@@ -217,10 +217,10 @@ organised by data category (saveframe).
     1. ALL string values are limited to printable 7-bit ASCII characters
     (codes 32 to 126 inclusive), plus line breaks for multiline strings.
 
-    2. 'sf_framecode's are limited to values that can be written in STAR without
+    2. 'sf\_framecode's are limited to values that can be written in STAR without
     the use of quotes. This means strings that do not contain whitespace,
     single or double quotes ('"), or the hash sign (#), and that do not start
-    with any of the following strings : '_', 'data_', 'save_', 'loop_', 'stop_'.
+    with any of the following strings : '\_', 'data\_', 'save\_', 'loop\_', 'stop\_'.
 
   * Enumerated types:
 
@@ -308,8 +308,10 @@ organised by data category (saveframe).
         Dummy residues that do not have a specific type (e.g. TNSR) should
         use code UNK.
 
-    Residues of type 'start', 'middle', and 'end' must have the appropriate
-    link to the next/preceding residue. Sequences flanked by a 'start'-'end'
+    Sequential linking within a given chain is inferred from the linking column
+    of consecutive residues. Residues of type 'start', 'middle', and 'end' must
+    have the appropriate link to the next/preceding residue in the same chain.
+    Sequences flanked by a 'start'-'end'
     pair or a 'cyclic'-'cyclic' pair denote a linear or cyclic linear polymer,
     respectively. The 'break' keyword is used when the first or last residue in
     a linear polymer stretch is not a chain terminal variant. This might be the
@@ -485,7 +487,7 @@ organised by data category (saveframe).
     orientation tensor in coordinate files. The 'residue_type' should be TNSR.
     Tensor values are given as magnitude and rhombicity.
 
-    2. The RDC estraint list can also be used to give non-reduced dipolar
+    2. The RDC restraint list can also be used to give non-reduced dipolar
     couplings.
 
     3. The 'restraint_origin' describes the origin or source of the restraints.

--- a/specification/mmcif_nef.dic
+++ b/specification/mmcif_nef.dic
@@ -1,0 +1,5077 @@
+###########################################################################
+#
+# File:  mmcif_nef.dic
+# Date:  Mon Feb  1 19:39:56 EST 2016
+#
+# Created from files in CVS module dict-mmcif_nef.dic unless noted:
+#        mmcif_nef-header.dic   
+#        mmcif_nef-data.dic   
+#        mmcif_nef-ext.dic   
+#
+###########################################################################
+ 
+ 
+###########################################################################
+# 
+#        NMR Exchange Format Data Dictionary (NEF)
+#                                                                           
+###########################################################################
+
+data_mmcif_nef.dic
+
+    _datablock.id                          mmcif_nef.dic
+    _datablock.description
+;
+     This data block holds the NMR Exchange Format Data Dictionary.
+
+     NMR Exchange Format Working:     Geerten Vuister (chair), Rasmus Fogh, Peter Güntert,
+     Charles Schwieters, Michael Nilges,T.J. Ragan,Torsten Herrmann, David A Case
+     Gaetano Montelione, David Wishart, Wim F. Vranken, Paul Adams, Roberto Tejero, Eldon Ulrich,
+     Naohiro Kobayashi, John Markley, Sameer Velankar, Aleksandras Gutmanas, John Westbrook
+ 
+;
+
+    _dictionary.title           mmcif_nef.dic
+    _dictionary.datablock_id    mmcif_nef.dic
+    _dictionary.version         .101
+#
+     loop_
+    _dictionary_history.version
+    _dictionary_history.update
+    _dictionary_history.revision
+  .100   2015-01-09
+; Changes (NEF Working Group):  Preliminary version release 
+
+     NMR Exchange Format Working:     Geerten Vuister (chair), Rasmus Fogh, Peter Güntert,
+     Charles Schwieters, Michael Nilges,T.J. Ragan,Torsten Herrmann, David A Case
+     Gaetano Montelione, David Wishart, Wim F. Vranken, Paul Adams, Roberto Tejero, Eldon Ulrich,
+     Naohiro Kobayashi, John Markley, Sameer Velankar, Aleksandras Gutmanas, John Westbrook
+;
+  .101   2016-02-23
+; Rasmus Fogh
+- Entered mising data
+- Reordered to match display ordered
+- Added new tag _category.parent_category_id to show saveframe location of loops
+- Added new data types
+;
+##
+
+###########################################################################
+#                           Data Section 
+#                                                                        
+###########################################################################
+
+
+
+##################
+## SUB_CATEGORY ##
+##################
+
+     loop_
+    _sub_category.id
+    _sub_category.description
+              'cartesian_coordinate'
+;              The collection of x, y, and z components of a position specified
+               with reference to a Cartesian (orthogonal angstrom) coordinate
+               system.
+;
+              'matrix'
+;              The collection of elements of a matrix.
+;
+
+#########################
+## CATEGORY_GROUP_LIST ##
+#########################
+
+     loop_
+    _category_group_list.id
+    _category_group_list.parent_id
+    _category_group_list.description
+              'inclusive_group'   .
+;              The parent category group containing all of the data categories in the macromolecular dictionary.
+;
+             'nef_group'
+             'inclusive_group'
+;             Categories which are used to storing categories in the NEF dictionary.
+;
+
+####################
+## ITEM_TYPE_LIST ##
+####################
+#
+#
+#  The regular expressions defined here are not compliant
+#  with the POSIX 1003.2 standard as they include the
+#  '\n' and '\t' special characters.  These regular expressions
+#  have been tested using version 0.12 of Richard Stallman's
+#  GNU regular expression library in POSIX mode.
+#
+#                                                                            
+# For some data items, a standard syntax is assumed. The syntax is           
+#   described for each data item in the dictionary, but is summarized here:  
+#                                                                            
+#   Names:     The family name(s) followed by a comma, precedes the first    
+#              name(s) or initial(s).                                        
+#                                                                            
+#   Telephone numbers:                                                       
+#              The international code is given in brackets and any extension 
+#              number is preceded by 'ext'.                                  
+#                                                                            
+#   Dates:     In the form yyyy-mm-dd.                                       
+#                                                                            
+##############################################################################
+
+     loop_
+    _item_type_list.code
+    _item_type_list.primitive_code
+    _item_type_list.construct
+    _item_type_list.detail
+               code      char
+               '[][_,.;:"&<>()/\{}'`~!@#$%A-Za-z0-9*|+-]*'
+;              code item types/single words ...
+;
+               ucode      uchar
+               '[][_,.;:"&<>()/\{}'`~!@#$%A-Za-z0-9*|+-]*'
+;              code item types/single words  (case insensitive) ...
+;
+               line      char
+               '[][ \t_(),.;:"&<>/\{}'`~!@#$%?+=*A-Za-z0-9|^-]*'
+;              char item types / multi-word items ...
+;
+               uline      uchar
+               '[][ \t_(),.;:"&<>/\{}'`~!@#$%?+=*A-Za-z0-9|^-]*'
+;              char item types / multi-word items (case insensitive)...
+;
+               text      char
+               '[][ \n\t()_,.;:"&<>/\{}'`~!@#$%?+=*A-Za-z0-9|^-]*'
+;              text item types / multi-line text ...
+;
+               int       numb
+               '[+-]?[0-9]+'
+;              int item types are the subset of numbers that are the negative or positive integers.
+;
+               float     numb
+          '-?(([0-9]+)[.]?|([0-9]*[.][0-9]+))([(][0-9]+[)])?([eE][+-]?[0-9]+)?'
+;              float item types are the subset of numbers that are the floating numbers.
+;
+               name      uchar
+               '_[_A-Za-z0-9]+\.[][_A-Za-z0-9%-]+'
+;              name item types take the form...
+;
+               idname    uchar
+               '[_A-Za-z0-9]+'
+;              idname item types take the form...
+;
+               any       char
+               '.*'
+;              A catch all for items that may take any form...
+;
+               yyyy-mm-dd  char
+                '[0-9]?[0-9]?[0-9][0-9]-[0-9]?[0-9]-[0-9][0-9]'
+;
+               Standard format for CIF dates.
+;
+               yyyy-mm-dd:hh:mm-flex  char
+                '[0-9][0-9][0-9][0-9](-[0-9]?[0-9])?(-[0-9][0-9])?(:[0-9]?[0-9]:[0-9][0-9])?'
+;
+               Flexible date-time format.
+;
+               uchar3    uchar
+              '[+]?[A-Za-z0-9][A-Za-z0-9]?[A-Za-z0-9]?'
+;
+               data item for 3 character codes
+;
+               uchar1    uchar
+              '[+]?[A-Za-z0-9]'
+;
+               data item for 1 character codes
+;
+               atcode      char
+               '[][ _(),.;:"&<>/\{}'`~!@#$%?+=*A-Za-z0-9|^-]*'
+;              Character data type for atom names  ...
+;
+               yyyy-mm-dd:hh:mm  char
+    '[0-9]?[0-9]?[0-9][0-9]-[0-9]?[0-9](-[0-9]?[0-9])?(:[0-9]?[0-9]:[0-9][0-9])?'
+;
+               Standard format for CIF dates with optional time stamp.
+;
+               fax      uchar
+               '[_,.;:"&<>/\{}'`~!@#$%A-Za-z0-9*|+-]*'
+;              code item types/single words  (case insensitive) ...
+;
+               phone      uchar
+               '[_,.;:"&<>/\{}'`~!@#$%A-Za-z0-9*|+-]*'
+;              code item types/single words  (case insensitive) ...
+;
+               email      uchar
+               '[_,.;:"&<>/\{}'`~!@#$%A-Za-z0-9*|+-]*'
+;              code item types/single words  (case insensitive) ...
+;
+               int-range       numb
+               '-?[0-9]+(--?[0-9]+)?'
+;              int item types are the subset of numbers that are the negative or positive integers with optional range.
+;
+               float-range     numb
+ '-?(([0-9]+)[.]?|([0-9]*[.][0-9]+))([(][0-9]+[)])?([eE][+-]?[0-9]+)?(--?(([0-9]+)[.]?|([0-9]*[.][0-9]+))([(][0-9]+[)])?([eE][+-]?[0-9]+)?)?'
+;              int item types are the subset of numbers that are the floating numbers.
+;
+# NMR-STAR additions
+
+              framecode   char
+              '[.;:"&<>(){}'`~!$%A-Za-z0-9*|+-][_.;:"&<>(){}'`~!$%A-Za-z0-9*|+-]*' 
+;             A value that points to a saveframe.
+;
+# NEF additions:
+               multiline    char
+               '[][ \n()_,.;:"&<>/\{}'`~!@#$%?+=*A-Za-z0-9|^-]*'
+;              All printable ascii characters (includind space) plus linebreak
+;
+               singleline    char
+               '[][ ()_,.;:"&<>/\{}'`~!@#$%?+=*A-Za-z0-9|^-]*'
+;              All printable ascii characters (includind space). Equivalent to atcode, but renamed to avoid confusion
+;
+               word    char
+               '[][()_,.;:"&<>/\{}'`~!@#$%?+=*A-Za-z0-9|^-]*'
+;              All printable ascii characters (NOT including space).
+;
+               nef_framecode    char
+               '[][()_,.;:&<>/\{}`~!@$%?+=*A-Za-z0-9|^-]*'
+;              Printable ascii characters (except for space, single or double quotes, or pound sign).
+               Values may also not start with reserved strings 'data_', 'save_', 'loop_', or 'stop_'.
+;
+               
+               boolean      char
+               'true|false'
+;              enumeration for Boolean true/false values ...
+;
+               timestamp      char
+               .
+;              ISO 8601 time stamp, without time zone information. E.g. '2013-02-29T13:12:03.521773'
+;
+               uuid      char
+               .
+;              Unique data set identifier, combined from a program name string, a timestamp, and a random integer.
+E.g. 'CYANA-2013-02-29T13:12:04.521773-1172436'
+;
+               potential_type      char
+               'undefined|log-harmonic|parabolic|square-well-parabolic|square-well-parabolic-linear|upper-bound-parabolic|lower-bound-parabolic|upper-bound-parabolic-linear|lower-bound-parabolic-linear'
+;              enumeration for Restraint list potential types
+Potential types are defined aS follows::
+
+- log-harmonic:
+Parameters: target_value, target_value_error
+
+- parabolic:
+Parameters: target_value, target_value_error
+Formula: E = k(r-target_value)**2
+
+- square-well-parabolic:
+Parameters: upper_limit, lower_limit (optionally: target_value, target_value_error)
+Formula:
+E = k(r-upper_limit)**\2 for r > upper_limit
+E = k(r-lower_limit)**2 for r < lower_limit
+
+- 'square-well-parabolic-linear:
+Parameters: upper_limit, lower_limit, upper_linear_limit, lower_linear_limit, (optional: target_value, target_value_error)
+Formula:
+If upper_limit = u, upper_linear_limit = u2, lower_limit = l, lower_linear_limit = l2:
+E = 2k(u2-u)(r - (u2+u)/2) for r > u2
+E = k(r-u)**2 for u < r < u2
+E = k(r-l)**2 for l > r > l2
+E = 2k(l2-l)(r - (l2+l)/2) for r < l2
+
+Additional potential types 
+('upper-bound-parabolic', 'lower-bound-parabolic', 'upper-bound-parabolic-linear', 'lower-bound-parabolic-linear')
+can be derived from the two-sided versions given above.
+;
+
+
+ 
+### EOF pdbx_nef-data.dic
+#data_NEFext
+#
+#
+#_dictionary.title         NEF-ext
+#_dictionary.datablock_id  NEF-ext
+#_dictionary.version       latest
+##
+
+#
+#   save_nef_nmr_meta_data
+#
+
+save_nef_nmr_meta_data
+   #
+
+   _category.description     "The data items in the NEF_NMR_META_DATA category records the format version and creator program details."
+   _category.id              nef_nmr_meta_data
+   _category.mandatory_code  yes
+   #
+   _category_group.id  nef_group
+   #   #
+   loop_
+   _category_key.name
+     "_nef_nmr_meta_data.sf_framecode"  
+   #
+   _category_examples.detail  "Example 1"
+   _category_examples.case    
+;   _nef_nmr_meta_data.sf_category           nef_nmr_meta_data
+   _nef_nmr_meta_data.sf_framecode          nef_nmr_meta_data
+   _nef_nmr_meta_data.format_name           nmr_exchange_format
+   _nef_nmr_meta_data.format_version        0.7
+   _nef_nmr_meta_data.program_name          CCPN
+   _nef_nmr_meta_data.program_version       2.4.1
+   _nef_nmr_meta_data.creation_date         2014-10-10T12:17:50.122945
+   _nef_nmr_meta_data.uuid                  CYANA-2013-02-29T13:12:04.521773-1172436
+   _nef_nmr_meta_data.coordinate_file_name  structures/ensemble5.cif
+;
+
+   #
+save_
+#
+save__nef_nmr_meta_data.sf_category
+   #
+
+   _item_description.description  "An identifier for the saveframe category (type)"
+   #
+   _item.name            "_nef_nmr_meta_data.sf_category"
+   _item.category_id     nef_nmr_meta_data
+   _item.mandatory_code  yes
+   #
+   _item_type.code  idname
+   #
+   _item_examples.case  nef_nmr_meta_data
+   #
+save_
+#
+save__nef_nmr_meta_data.sf_framecode
+   #
+
+   _item_description.description  "An identifier for the saveframe."
+   #
+   _item.name            "_nef_nmr_meta_data.sf_framecode"
+   _item.category_id     nef_nmr_meta_data
+   _item.mandatory_code  yes
+   #
+   _item_type.code  nef_framecode
+   #
+   _item_examples.case  nef_nmr_meta_data
+   #
+save_
+#
+save__nef_nmr_meta_data.format_name
+   #
+
+   _item_description.description  "The format identifier for this data set."
+   #
+   _item.name            "_nef_nmr_meta_data.format_name"
+   _item.category_id     nef_nmr_meta_data
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  Nmr_Exchange_Format
+   #
+save_
+#
+save__nef_nmr_meta_data.format_version
+   #
+
+   _item_description.description  "The format version for this data set."
+   #
+   _item.name            "_nef_nmr_meta_data.format_version"
+   _item.category_id     nef_nmr_meta_data
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  0.8
+   #
+save_
+#
+save__nef_nmr_meta_data.program_name
+   #
+
+   _item_description.description  "The creator program name for this data file."
+   #
+   _item.name            "_nef_nmr_meta_data.program_name"
+   _item.category_id     nef_nmr_meta_data
+   _item.mandatory_code  yes
+   #
+   _item_type.code  singleline
+   #
+   _item_examples.case  'CcpNmr Analysis'
+   #
+save_
+#
+save__nef_nmr_meta_data.program_version
+   #
+
+   _item_description.description  "The creator program version for this data file."
+   #
+   _item.name            "_nef_nmr_meta_data.program_version"
+   _item.category_id     nef_nmr_meta_data
+   _item.mandatory_code  yes
+   #
+   _item_type.code  singleline
+   #
+   _item_examples.case  3.1
+   #
+save_
+#
+save__nef_nmr_meta_data.creation_date
+   #
+
+   _item_description.description  "The creation date for this data set."
+   #
+   _item.name            "_nef_nmr_meta_data.creation_date"
+   _item.category_id     nef_nmr_meta_data
+   _item.mandatory_code  yes
+   #
+   _item_type.code  timestamp
+   #
+   _item_examples.case  2013-02-29T13:12:03.521773
+   #
+save_
+#
+save__nef_nmr_meta_data.uuid
+   #
+
+   _item_description.description  "The universal identifier for this data sert."
+   #
+   _item.name            "_nef_nmr_meta_data.uuid"
+   _item.category_id     nef_nmr_meta_data
+   _item.mandatory_code  yes
+   #
+   _item_type.code  uuid
+   #
+   _item_examples.case  CYANA-2013-02-29T13:12:04.521773-1172436
+   #
+save_
+
+
+#
+save__nef_nmr_meta_data.coordinate_file_name
+   #
+
+   _item_description.description  "The coordinate data file name associated with this restraint data set."
+   #
+   _item.name            "_nef_nmr_meta_data.coordinate_file_name"
+   _item.category_id     nef_nmr_meta_data
+   _item.mandatory_code  no
+   #
+   _item_type.code  singleline
+   #
+   _item_examples.case  structures/CAM5_run2.cif
+   #
+save_
+
+#
+save_nef_related_entries
+   #
+
+   _category.description          "The data items in the NEF_RELATED_ENTRIES category provide the list of database names and accession codes related to this data set."
+   _category.id                   nef_related_entries
+   _category.parent_category_id   nef_nmr_meta_data
+   _category.mandatory_code       no
+   #
+   _category_group.id  nef_group
+   #   #
+   loop_
+   _category_key.name
+     "_nef_related_entries.database_accession_code"  
+     "_nef_related_entries.database_name"  
+   #
+   _category_examples.detail  "Example 1"
+   _category_examples.case    
+;  _nef_related_entries.database_name
+  _nef_related_entries.database_accession_code
+    BMRB   12345
+    BMRB   22277
+    PDB    2k5v
+    PDB    2hhx
+    PDB    1aap
+   stop_
+;
+   #
+save_
+#
+save__nef_related_entries.database_name
+   #
+
+   _item_description.description  "The database name for the related data set."
+   #
+   _item.name            "_nef_related_entries.database_name"
+   _item.category_id     nef_related_entries
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  BMRB
+   #
+save_
+#
+save__nef_related_entries.database_accession_code
+   #
+
+   _item_description.description  "The database accession code for a related data set."
+   #
+   _item.name            "_nef_related_entries.database_accession_code"
+   _item.category_id     nef_related_entries
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  1aap
+   #
+save_
+#
+save_nef_program_script
+   #
+
+   _category.description     "The data items in the NEF_PROGRAM_SCRIPT category records the list of programs and scripts used in producing this data set."
+   _category.id              nef_program_script
+   _category.parent_category_id   nef_nmr_meta_data
+   _category.mandatory_code  no
+   #
+   _category_group.id  nef_group
+   #   #
+   loop_
+   _category_key.name
+     "_nef_program_script.program_name"  
+     "_nef_program_script.script_name"  
+   #
+   _category_examples.detail  "Example 1"
+   _category_examples.case    
+;   loop_
+      _nef_program_script.program_name
+      _nef_program_script.script_name
+      _nef_program_script.script
+     'CcpNmr Analysis' dummy      'Try  something, then say 'Booh!''
+;
+
+   #
+save_
+#
+save__nef_program_script.program_name
+   #
+
+   _item_description.description  "The program name invoked by this script."
+   #
+   _item.name            "_nef_program_script.program_name"
+   _item.category_id     nef_program_script
+   _item.mandatory_code  yes
+   #
+   _item_type.code  singleline
+   #
+   _item_examples.case  CYANA
+   #
+save_
+#
+save__nef_program_script.script_name
+   #
+
+   _item_description.description  "The name for the script."
+   #
+   _item.name            "_nef_program_script.script_name"
+   _item.category_id     nef_program_script
+   _item.mandatory_code  no
+   #
+   _item_type.code  singleline
+   #
+   _item_examples.case  init2.cya
+   #
+save_
+#
+save__nef_program_script.script
+   #
+
+   _item_description.description  "The text of the script."
+   #
+   _item.name            "_nef_program_script.script"
+   _item.category_id     nef_program_script
+   _item.mandatory_code  no
+   #
+   _item_type.code  multiline
+   #
+   _item_examples.case  
+;
+rmsdrange:=1-93
+
+cyanalib
+
+read seq protein.seq
+;
+   #
+save_
+#
+save_nef_run_history
+   #
+
+   _category.description          "The data items in the NEF_RELATED_ENTRIES category enumerate the program steps related to the current data set."
+   _category.id                   nef_run_history
+   _category.parent_category_id   nef_nmr_meta_data
+   _category.mandatory_code       no
+   #
+   _category_group.id             nef_group
+   #
+   _category_key.name             "_nef_run_history.run_ordinal"
+   #
+   _category_examples.detail  "Example 1"
+   _category_examples.case    
+;   loop_
+      _nef_run_history.run_ordinal
+      _nef_run_history.program_name
+      _nef_run_history.program_version
+      _nef_run_history.script_name
+      _nef_run_history.script
+     1   'CcpNmr Analysis' 2.4.1   autoSetupRun   .                                                    
+     2   Cyana             3.0     init.cya       
+ ;
+ rmsdrange:=1-93
+ cyanalib
+ read seq protein.seq
+ ;
+;
+
+   #
+save_
+#
+save__nef_run_history.run_ordinal
+   #
+
+   _item_description.description  "A unique and ordered identifier for program steps related to this data set."
+   #
+   _item.name            "_nef_run_history.run_ordinal"
+   _item.category_id     nef_run_history
+   _item.mandatory_code  yes
+   #
+   _item_type.code       int
+   #
+   _item_examples.case   1
+   #
+save_
+#
+save__nef_run_history.program_name
+   #
+
+   _item_description.description  "The program name associated with the current step. "
+   #
+   _item.name            "_nef_run_history.program_name"
+   _item.category_id     nef_run_history
+   _item.mandatory_code  yes
+   #
+   _item_type.code  singleline
+   #
+   _item_examples.case  'Bruker TOPSPIN'
+   #
+save_
+#
+save__nef_run_history.program_version
+   #
+
+   _item_description.description  "The program version associated with the current step. "
+   #
+   _item.name            "_nef_run_history.program_version"
+   _item.category_id     nef_run_history
+   _item.mandatory_code  no
+   #
+   _item_type.code       singleline
+   #
+   _item_examples.case   3.1
+   #
+save_
+#
+save__nef_run_history.script_name
+   #
+
+   _item_description.description  "The program script name associated with the current step. "
+   #
+   _item.name            "_nef_run_history.script_name"
+   _item.category_id     nef_run_history
+   _item.mandatory_code  no
+   #
+   _item_type.code  singleline
+   #
+   _item_examples.case  mypulprog.name
+   #
+save_
+#
+save__nef_run_history.script
+   #
+
+   _item_description.description  "The program script associated with the current step. "
+   #
+   _item.name            "_nef_run_history.script"
+   _item.category_id     nef_run_history
+   _item.mandatory_code  no
+   #
+   _item_type.code  multiline
+   #
+   _item_examples.case  
+;
+INSERT PULSE PROGRAM HERE
+
+;
+   #
+save_
+
+#
+#          nef_molecular_system
+#
+
+
+#
+save_nef_molecular_system
+   #
+
+   _category.description     "The data items in the NEF_MOLECULAR_SYSTEM category provides details describing the molecular system."
+   _category.id              nef_molecular_system
+   _category.mandatory_code  yes
+   #
+   _category_group.id        nef_group
+   #   #
+   loop_
+   _category_key.name
+     "_nef_molecular_system.sf_framecode"  
+   #
+   _category_examples.detail  "Example 1"
+   _category_examples.case    
+;   _nef_molecular_system.sf_category   nef_molecular_system
+   _nef_molecular_system.sf_framecode  nef_molecular_system
+;
+
+   #
+save_
+#
+save__nef_molecular_system.sf_category
+   #
+
+   _item_description.description  "An identifier for the saveframe category (type)"
+   #
+   _item.name            "_nef_molecular_system.sf_category"
+   _item.category_id     nef_molecular_system
+   _item.mandatory_code  yes
+   #
+   _item_type.code  idname
+   #
+   _item_examples.case  nef_molecular_system
+   #
+save_
+#
+save__nef_molecular_system.sf_framecode
+   #
+
+   _item_description.description  "An identifier for the saveframe"
+   #
+   _item.name            "_nef_molecular_system.sf_framecode"
+   _item.category_id     nef_molecular_system
+   _item.mandatory_code  yes
+   #
+   _item_type.code  nef_framecode
+   #
+   _item_examples.case  nef_molecular_system
+   #
+save_
+
+#
+save_nef_sequence
+   #
+
+   _category.description          "The data items in the NEF_SEQUENCE category enumerates the sequences of the polymer components of the molecular system."
+   _category.id                   nef_sequence
+   _category.parent_category_id   nef_molecular_system
+   _category.mandatory_code       yes
+   #
+   _category_group.id  nef_group
+   #   #
+   loop_
+   _category_key.name
+     "_nef_sequence.chain_code"  
+     "_nef_sequence.sequence_code"  
+     "_nef_sequence.residue_type"  
+   #
+   _category_examples.detail  "Example 1"
+   _category_examples.case    
+;  loop_
+    _nef_sequence.chain_code
+    _nef_sequence.sequence_code
+    _nef_sequence.residue_type
+    _nef_sequence.linking
+    _nef_sequence.residue_variant
+
+  # key: chain_code, sequence_code
+
+    A   13  ALA   start      .
+    A   14  TRP   middle     .
+    A   15  GLY   middle     .
+    A   16  ASN   middle     .
+    A   17  VAL   middle     .
+    A   18  PHE   middle     .
+    A   19  LEU   middle     .
+    A   20  CYS   middle     .
+    A   21  ALA   middle     .
+    A   22  THR   middle     .
+    A   23  LYS   middle     .
+    A   24  ASP   middle     .
+    A   25  HIS   end	     .
+    A   26  GLC   nonlinear  .
+    B   17  CYS   single     .
+    C    1  ATP   nonlinear  .
+    C  898  UNK   dummy      .
+    C  899  UNK   dummy      .
+    C  900  TNSR  dummy      .
+    D    1  GLY   cyclic     .
+    D    2  PRO   middle     .
+    D    3  ASP   middle     ASP_LL
+    D    4  GLY   middle     .
+    D    5  PRO   middle     .
+    D    6  ASP   cyclic     .
+    E    1  ASN   break      .
+    E    2  THR   middle     .
+    E    3  ALA   middle     .
+    E    4  PRO   middle     .
+    E    5  ALA   middle     .
+    E    6  GLU   middle     .
+    E    6B SER   middle     .
+    E    7  GLN   middle     .
+    E    8  GLU	  middle     GLU_LL
+    E    9  HIS	  middle     HIS_LL_DHD1
+    E   10  HIS	  middle     HIS_LL
+    E   11  CYS	  middle     .
+    E   12  LYS	  middle     LYS_LL_DHZ3
+    E   13  ARG	  break      ARG_LL_DHH12
+    E   14  MOH   nonlinear  .
+  stop_
+  
+# Chain A is a linear dodecapeptide (15-25), disulfide linked to a single
+# cysteine, with a glucose linked to THR 22
+# The GLC is given with chaincode A, the CYS with code B; both forms are allowed
+#
+# Chain C is free ATP
+#
+# Chain D is a cyclic hexapeptide
+#
+# Chain E has an amide bond between the backbone N of ASN 1 and the side chain carboxylate
+# of GLU 6, and a methyl ester cap.
+#
+# residue_variants default to the pH 7 forms, specifically protonated LYS, ARG, and N-terminus
+# and deprotonated ASP, GLU, and C-terminus. 
+# Chain E shows examples of how to specify the non-default forms supported by the NEF format.
+#
+# The current version does not allow specifying atoms that areremoved to give placxe for _nef_covalent_links# A change proposal is in place
+;
+   #
+save_
+#
+save__nef_sequence.chain_code
+   #
+
+   _item_description.description  "The author provided identifier for a polymer chain identifier for this sequence."
+   #
+   _item.name            "_nef_sequence.chain_code"
+   _item.category_id     nef_sequence
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  B
+   #
+save_
+#
+save__nef_sequence.sequence_code
+   #
+
+   _item_description.description  "The author provided position for the residue in the sequence."
+   #
+   _item.name            "_nef_sequence.sequence_code"
+   _item.category_id     nef_sequence
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   loop_
+   _item_examples.case
+   20
+   233B
+   stop_
+   #
+save_
+#
+save__nef_sequence.residue_type
+   #
+
+   _item_description.description  "The author provided residue name."
+   #
+   _item.name            "_nef_sequence.residue_type"
+   _item.category_id     nef_sequence
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  ALA
+   #
+save_
+#
+save__nef_sequence.linking
+   #
+
+   _item_description.description  "A code to describe sequential linking status of the residue."
+   #
+   _item.name            "_nef_sequence.linking"
+   _item.category_id     nef_sequence
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  middle
+   #
+   loop_
+     _item_enumeration.value
+       start
+       end
+       middle
+       cyclic
+       break
+       single
+       nonlinear
+       dummy
+    stop_
+save_
+#
+save__nef_sequence.residue_variant
+   #
+
+   _item_description.description  
+;Residue varinats default to the pH 7 forms, specifically protonated LYS, ARG, HIS, and N-terminus
+and deprotonated ASP, GLU, CYS, and C-terminus. 'deprotonated' CYS is generally assumed to be the 
+disulfide form. Where given teh RCSB variant code is used. Ther is no decision on what to use where 
+these codes are not defined.
+;
+   #
+   _item.name            "_nef_sequence.residue_variant"
+   _item.category_id     nef_sequence
+   _item.mandatory_code  no
+   #
+   _item_type.code  singleline
+   #
+   loop_
+   _item_examples.case  
+     CYS_LL
+     ARG_LSN3_DHH12
+   stop_
+   #
+save_
+#
+
+
+save_nef_covalent_links
+   #
+
+   _category.description          "The data items in the NEF_COVALENT_LINKS category provide the list of covalent linkages among the components of the molecular system."
+   _category.id                   nef_covalent_links
+   _category.parent_category_id   nef_molecular_system
+   _category.mandatory_code       no
+   #
+   _category_group.id             nef_group
+   #   #
+   loop_
+   _category_key.name
+     "_nef_covalent_links.chain_code_1"  
+     "_nef_covalent_links.residue_type_1"  
+     "_nef_covalent_links.sequence_code_1"  
+     "_nef_covalent_links.atom_name_1"  
+     "_nef_covalent_links.chain_code_2"  
+     "_nef_covalent_links.sequence_code_2"   
+     "_nef_covalent_links.residue_type_2" 
+     "_nef_covalent_links.atom_name_2"  
+   #
+   _category_examples.detail  "Example 1"
+   _category_examples.case    
+;   loop_
+     _nef_covalent_links.chain_code_1
+     _nef_covalent_links.sequence_code_1
+     _nef_covalent_links.residue_type_1
+     _nef_covalent_links.atom_name_1
+     _nef_covalent_links.chain_code_2
+     _nef_covalent_links.sequence_code_2
+     _nef_covalent_links.residue_type_2
+     _nef_covalent_links.atom_name_2
+     B   3   CYS   SG   B   6   CYS   SG
+     B   5   THR   OG1  B   9   GLN   C
+;
+
+   #
+save_
+#
+save__nef_covalent_links.chain_code_1
+   #
+
+   _item_description.description  "The author provided name for the first polymer chain or ligand instance."
+   #
+   _item.name            "_nef_covalent_links.chain_code_1"
+   _item.category_id     nef_covalent_links
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  A
+   #
+save_
+#
+save__nef_covalent_links.sequence_code_1
+   #
+
+   _item_description.description  "The author provided position for the first residue in the sequence."
+   #
+   _item.name            "_nef_covalent_links.sequence_code_1"
+   _item.category_id     nef_covalent_links
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  20
+   #
+save_
+#
+save__nef_covalent_links.residue_type_1
+   #
+
+   _item_description.description  "The author provided name for the first partner residue."
+   #
+   _item.name            "_nef_covalent_links.residue_type_1"
+   _item.category_id     nef_covalent_links
+   _item.mandatory_code  yes
+   #
+   _item_type.code  code
+   #
+   _item_examples.case  CYS
+   #
+save_
+save__nef_covalent_links.atom_name_1
+   #
+
+   _item_description.description  "The author provided name for the first partner atom."
+   #
+   _item.name            "_nef_covalent_links.atom_name_1"
+   _item.category_id     nef_covalent_links
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  SD
+   #
+save_
+#
+#
+save__nef_covalent_links.chain_code_2
+   #
+
+   _item_description.description  "The author provided name for the second polymer chain or ligand instance."
+   #
+   _item.name            "_nef_covalent_links.chain_code_2"
+   _item.category_id     nef_covalent_links
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  B
+   #
+save_
+#
+save__nef_covalent_links.sequence_code_2
+   #
+
+   _item_description.description  "The author provided position for the second residue in the sequence."
+   #
+   _item.name            "_nef_covalent_links.sequence_code_2"
+   _item.category_id     nef_covalent_links
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  127B
+   #
+save_
+#
+save__nef_covalent_links.residue_type_2
+   #
+
+   _item_description.description  "The author provided name for the second partner residue."
+   #
+   _item.name            "_nef_covalent_links.residue_type_2"
+   _item.category_id     nef_covalent_links
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  CYS
+   #
+save_
+save__nef_covalent_links.atom_name_2
+   #
+
+   _item_description.description  "The author provided name for the second partner atom."
+   #
+   _item.name            "_nef_covalent_links.atom_name_2"
+   _item.category_id     nef_covalent_links
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  SD
+   #
+save_
+#
+
+#
+#                   nef_chemical_shift_list
+#
+
+#
+save_nef_chemical_shift_list
+   #
+
+   _category.description     "The data items in the NEF_CHEMICAL_SHIFT_LIST category provides additional details about the list of chemical shifts."
+   _category.id              nef_chemical_shift_list
+   _category.mandatory_code  yes
+   #
+   _category_group.id  nef_group
+   #   #
+   loop_
+   _category_key.name
+     "_nef_chemical_shift_list.sf_framecode"  
+   #
+   _category_examples.detail  "Example 1"
+   _category_examples.case    
+;   _nef_chemical_shift_list.sf_category                nef_chemical_shift_list
+   _nef_chemical_shift_list.sf_framecode               nef_chemical_shift_list_bmrb21_str
+   _nef_chemical_shift_list.atom_chemical_shift_units  ppm
+;
+   #
+save_
+#
+save__nef_chemical_shift_list.sf_category
+   #
+
+   _item_description.description  "An identifier for the saveframe category (type)"
+   #
+   _item.name            "_nef_chemical_shift_list.sf_category"
+   _item.category_id     nef_chemical_shift_list
+   _item.mandatory_code  yes
+   #
+   _item_type.code  idname
+   #
+   _item_examples.case  nef_chemical_shift_list
+   #
+save_
+#
+save__nef_chemical_shift_list.sf_framecode
+   #
+
+   _item_description.description  "An identifier for the saveframe"
+   #
+   _item.name            "_nef_chemical_shift_list.sf_framecode"
+   _item.category_id     nef_chemical_shift_list
+   _item.mandatory_code  yes
+   #
+   _item_type.code  nef_framecode
+   #
+   _item_examples.case  nef_chemical_shift_list_bmrb21_str
+   #
+save_
+#
+save__nef_chemical_shift_list.atom_chemical_shift_units
+   #
+
+   _item_description.description  "The units of chemical shift values in the NEF_CHEMICAL_SHIFT category."
+   #
+   _item.name            "_nef_chemical_shift_list.atom_chemical_shift_units"
+   _item.category_id     nef_chemical_shift_list
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  ppm
+   #
+save_
+
+#
+save_nef_chemical_shift
+   #
+
+   _category.description     "The data items in the NEF_CHEMICAL_SHIFT category enumerate the list of chemical shifts."
+   _category.id              nef_chemical_shift
+   _category.parent_category_id   nef_chemical_shift_list
+   _category.mandatory_code  yes
+   #
+   _category_group.id  nef_group
+   #   #
+   loop_
+   _category_key.name  
+     "_nef_chemical_shift.chain_code"  
+     "_nef_chemical_shift.sequence_code"  
+     "_nef_chemical_shift.residue_type"  
+     "_nef_chemical_shift.atom_name"
+   #
+   _category_examples.detail  "Example 1"
+   _category_examples.case    
+;   loop_
+      _nef_chemical_shift.chain_code
+      _nef_chemical_shift.sequence_code
+      _nef_chemical_shift.residue_type
+      _nef_chemical_shift.atom_name
+      _nef_chemical_shift.value
+      _nef_chemical_shift.value_uncertainty
+
+      A	15	GLY	QA	 3.42	0.02
+      A 17      VAL     HG%      0.73   0.02
+      A 17      VAL     CG%     22.1    0.3
+      A 18      PHE     HB2      2.87   0.02
+      A 18      PHE     HB3      2.42   0.02
+      A 19      LEU     HBX      2.13   0.02
+      A 19      LEU     HBY      2.51   0.02
+      A 19      LEU     HDX%     0.87   0.02
+      A 19      LEU     HDY%     0.73   0.02
+      A 19      LEU     CDX     17.4    0.3
+      A 19      LEU     CDY     18.7    0.3
+      A 21      ALA     HA       4.17   0.02
+      A 21      ALA     H        8.33   0.02
+      A 21      ALA     HB%      1.34   0.02
+      A 23      LYS     HA       4.27   0.02
+      A 23      LYS     H        8.45   0.04
+      A 23      LYS     CA      43.2    0.25
+      A 23      LYS     N      123.45   0.4
+     @1 SS@231  GLX?    CAi-1   48.2     .
+     @1 SS@12      .    CAi-1   39.2     .
+  stop_
+  
+
+# The atom_name by itself serves to distinguish between real atoms ('HA'),
+#  pseudoatoms ('QA'), sets of atoms ('HB%'), sterospecifically assigned atoms
+# ('HB2'), and non-stereospecifically assigned atoms ('HBX').
+# In the example, Phe 18 HB2/HB3 are stereospecifically assigned, while Leu 19
+# is not.
+# Gly 15 QA is a pseudoatom, i.e. an atom at the HA2/HA3 centroid with zero van
+# der Waals radius.
+# Val 17 HG%/CG% show two methyl groups that overlap in both carbon and proton
+# dimensions.
+# 19 LEU HDX% is the methyl bound to CDX (and not to CDY).
+# The last two shifts (with chain_code @1) are unassigned but observed resonances,
+;
+
+   #
+save_
+#
+#
+save__nef_chemical_shift.chain_code
+   #
+
+   _item_description.description  "The author provided identifier for a polymer chain or ligand instance."
+   #
+   _item.name            "_nef_chemical_shift.chain_code"
+   _item.category_id     nef_chemical_shift
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  B
+   #
+save_
+save__nef_chemical_shift.sequence_code
+   #
+
+   _item_description.description  "The author provided residue position in sequence."
+   #
+   _item.name            "_nef_chemical_shift.sequence_code"
+   _item.category_id     nef_chemical_shift
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   loop_
+     _item_examples.case  
+     20
+     33C
+   stop_
+   #
+save_
+#
+save__nef_chemical_shift.residue_type
+   #
+
+   _item_description.description  "The author provided residue name."
+   #
+   _item.name            "_nef_chemical_shift.residue_type"
+   _item.category_id     nef_chemical_shift
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  ALA
+   #
+save_
+save__nef_chemical_shift.atom_name
+   #
+
+   _item_description.description  "The author provided atom name."
+   #
+   _item.name            "_nef_chemical_shift.atom_name"
+   _item.category_id     nef_chemical_shift
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   loop_
+     _item_examples.case  
+     HB1
+     C@75+0
+   stop_
+   #
+save_
+#
+#
+save__nef_chemical_shift.value
+   #
+
+   _item_description.description  "The chemical shift value."
+   #
+   _item.name            "_nef_chemical_shift.value"
+   _item.category_id     nef_chemical_shift
+   _item.mandatory_code  yes
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  5.22
+   #
+save_
+#
+save__nef_chemical_shift.value_uncertainty
+   #
+
+   _item_description.description  "The uncertainty in the chemical shift value."
+   #
+   _item.name            "_nef_chemical_shift.value_uncertainty"
+   _item.category_id     nef_chemical_shift
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  0.02
+   #
+save_
+#
+
+#
+#               nef_distance_restraint_list
+#
+
+
+
+save_nef_distance_restraint_list
+   #
+
+   _category.description     "The data items in the NEF_DISTANCE_RESTRAINT_LIST category provides additional details about the list of distance of restraints."
+   _category.id              nef_distance_restraint_list
+   _category.mandatory_code  no
+   #
+   _category_group.id  nef_group
+   #   #
+   loop_
+   _category_key.name
+     "_nef_distance_restraint_list.sf_framecode"  
+   #
+   _category_examples.detail  "Example 1"
+   _category_examples.case    
+;   _nef_dihedral_restraint_list.sf_category     nef_distance_restraint_list
+   _nef_dihedral_restraint_list.sf_framecode    nef_distance_restraint_list_ambig_2
+   _nef_dihedral_restraint_list.potential_type  square-well-parabolic-linear
+;
+
+   #
+save_
+#
+save__nef_distance_restraint_list.sf_category
+   #
+
+   _item_description.description  "An identifier for the saveframe category (type)"
+   #
+   _item.name            "_nef_distance_restraint_list.sf_category"
+   _item.category_id     nef_distance_restraint_list
+   _item.mandatory_code  yes
+   #
+   _item_type.code  int
+   #
+   _item_examples.case  1
+   #
+save_
+#
+save__nef_distance_restraint_list.sf_framecode
+   #
+
+   _item_description.description  "An identifier for the saveframe"
+   #
+   _item.name            "_nef_distance_restraint_list.sf_framecode"
+   _item.category_id     nef_distance_restraint_list
+   _item.mandatory_code  yes
+   #
+   _item_type.code  int
+   #
+   _item_examples.case  1
+   #
+save_
+#
+save__nef_distance_restraint_list.potential_type
+   #
+
+   _item_description.description  'The potential type used to model the distance restraints.'
+
+   #
+   _item.name            "_nef_distance_restraint_list.potential_type"
+   _item.category_id     nef_distance_restraint_list
+   _item.mandatory_code  yes
+   #
+   _item_type.code  potential_type
+   #
+   _item_examples.case  unknown
+   #
+save_
+#
+save__nef_distance_restraint_list.restraint_origin
+   #
+
+   _item_description.description  "The source of the restraints (e.g. 'noe', 'hbond', 'measured'."
+
+   #
+   _item.name            "_nef_distance_restraint_list.restraint_origin"
+   _item.category_id     nef_distance_restraint_list
+   _item.mandatory_code  no
+   #
+   _item_type.code  singleline
+   #
+   _item_examples.case  noe
+   #
+save_
+#
+save_nef_distance_restraint
+   #
+
+   _category.description          "The data items in the NEF_DISTANCE_RESTRAINT category enumerates the list of distance restraint contributions."
+   _category.id                   nef_distance_restraint
+   _category.parent_category_id   nef_distance_restraint_list
+   _category.mandatory_code       no
+   #
+   _category_group.id             nef_group
+   #   #
+   _category_key.name             '_nef_distance_restraint.ordinal'
+   #
+   _category_examples.detail  "Example 1"
+   _category_examples.case    
+;  loop_
+    _nef_distance_restraint.ordinal
+    _nef_distance_restraint.restraint_id
+    _nef_distance_restraint.restraint_combination_id
+    _nef_distance_restraint.chain_code_1
+    _nef_distance_restraint.sequence_code_1
+    _nef_distance_restraint.residue_type_1
+    _nef_distance_restraint.atom_name_1
+    _nef_distance_restraint.chain_code_2
+    _nef_distance_restraint.sequence_code_2
+    _nef_distance_restraint.residue_type_2
+    _nef_distance_restraint.atom_name_2
+    _nef_distance_restraint.weight
+    _nef_distance_restraint.target_value
+    _nef_distance_restraint.target_value_uncertainty
+    _nef_distance_restraint.lower_linear_limit
+    _nef_distance_restraint.lower_limit
+    _nef_distance_restraint.upper_limit
+    _nef_distance_restraint.upper_linear_limit
+    
+    1  1  .   A 21   ALA  HB%  A 17  VAL  H   1.00 3.7  0.4   2.0  2.5  4.2  4.7
+    2  1  .   A 21   ALA  HB%  A 18  LEU  H   1.00 3.7  0.4   2.0  2.5  4.2  4.7
+    3  1  .   A 22   THR  HG2% A 17  VAL  H   1.00 3.7  0.4   2.0  2.5  4.2  4.7
+    4  1  .   A 22   THR  HG2% A 18  LEU  H   1.00 3.7  0.4   2.0  2.5  4.2  4.7
+    5  5  .   A 18   PHE  HB2  A 24  ASP  HBX 1.00 2.8  0.4   1.5  2.0  3.2  3.7
+    6  8  .   A 18   PHE  HB2  A 24  ASP  HBY 1.00 4.4  0.4   3.6  4.1  5.2  5.7
+    6  8  .   E 6B   SER  HB2  A 24  ASP  HBY 1.00 4.4  0.4   3.6  4.1  5.2  5.7
+  stop_
+
+  # The first column (ordinal) is a consecutive line number that does not persist  
+  # when data are re-exported
+  # The second column gives the restraint ID.
+  # Lines 9cxontgributions) with the same restraint_id are combined into a single restraint
+  # (OR operations, effectively an ambiguous assignment).
+  # The restraint_combination_id is used for more complex logic,
+  # see dihedral restrains for an example.
+
+  # Each line (sub-restraint) of the table has its own independent
+  # parameters (weight, target_value, upper_limit, etc.), which may be different
+  # within the same restraint.
+;
+
+   #
+save_
+#
+save__nef_distance_restraint.ordinal
+   #
+
+   _item_description.description  "Line number for the restraint loop - not preserved when data are read."
+   #
+   _item.name            "_nef_distance_restraint.ordinal"
+   _item.category_id     nef_distance_restraint
+   _item.mandatory_code  yes
+   #
+   _item_type.code  int
+   #
+   _item_examples.case  1
+   #
+save_
+#
+save__nef_distance_restraint.restraint_id
+   #
+
+   _item_description.description  "An identifier used for this distance restraint."
+   #
+   _item.name            "_nef_distance_restraint.restraint_id"
+   _item.category_id     nef_distance_restraint
+   _item.mandatory_code  yes
+   #
+   _item_type.code  int
+   #
+   _item_examples.case  1
+   #
+save_
+#
+save__nef_distance_restraint.restraint_combination_id
+   #
+
+   _item_description.description  
+; An identifier for a restraint item combination within a distance restraint.
+Restraint items with the same restraint_combination_id must be part of the same restraint.
+When calculating a restraint they are AND-ed together, while contributions with different
+restraint_combination_id (or none) are ORed.
+;
+   #
+   _item.name            "_nef_distance_restraint.restraint_combination_id"
+   _item.category_id     nef_distance_restraint
+   _item.mandatory_code  no
+   #
+   _item_type.code  int
+   #
+   _item_examples.case  1
+   #
+save_
+#
+save__nef_distance_restraint.chain_code_1
+   #
+
+   _item_description.description  "The author provided name for the first partner chain or ligand instance."
+   #
+   _item.name            "_nef_distance_restraint.chain_code_1"
+   _item.category_id     nef_distance_restraint
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  B
+   #
+save_
+#
+save__nef_distance_restraint.sequence_code_1
+   #
+
+   _item_description.description  "The author provided position for the first partner residue"
+   #
+   _item.name            "_nef_distance_restraint.sequence_code_1"
+   _item.category_id     nef_distance_restraint
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  20
+   #
+save_
+#
+save__nef_distance_restraint.residue_type_1
+   #
+
+   _item_description.description  "The author provided name for the first partner residue."
+   #
+   _item.name            "_nef_distance_restraint.residue_type_1"
+   _item.category_id     nef_distance_restraint
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  ALA
+   #
+save_
+#
+save__nef_distance_restraint.atom_name_1
+   #
+
+   _item_description.description  "The author provided name for the first partner atom."
+   #
+   _item.name            "_nef_distance_restraint.atom_name_1"
+   _item.category_id     nef_distance_restraint
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  HB1
+   #
+save_
+#
+save__nef_distance_restraint.chain_code_2
+   #
+
+   _item_description.description  "The author provided name for the second partner chain or ligand instance."
+   #
+   _item.name            "_nef_distance_restraint.chain_code_2"
+   _item.category_id     nef_distance_restraint
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  D
+   #
+save_
+#
+save__nef_distance_restraint.sequence_code_2
+   #
+
+   _item_description.description  "The author provided position for the second partner residue"
+   #
+   _item.name            "_nef_distance_restraint.sequence_code_2"
+   _item.category_id     nef_distance_restraint
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  17B
+   #
+save_
+#
+save__nef_distance_restraint.residue_type_2
+   #
+
+   _item_description.description  "The author provided name for the second partner residue."
+   #
+   _item.name            "_nef_distance_restraint.residue_type_2"
+   _item.category_id     nef_distance_restraint
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  VAL
+   #
+save_
+#
+save__nef_distance_restraint.atom_name_2
+   #
+
+   _item_description.description  "The author provided name for the second partner atom."
+   #
+   _item.name            "_nef_distance_restraint.atom_name_2"
+   _item.category_id     nef_distance_restraint
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  HGX%
+   #
+save_
+#
+save__nef_distance_restraint.weight
+   #
+
+   _item_description.description  "The weighting value applied to the distance restraint value."
+   #
+   _item.name            "_nef_distance_restraint.weight"
+   _item.category_id     nef_distance_restraint
+   _item.mandatory_code  yes
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  1.00
+   #
+save_
+#
+save__nef_distance_restraint.target_value
+   #
+
+   _item_description.description  "The target value for the distance restraint value."
+   #
+   _item.name            "_nef_distance_restraint.target_value"
+   _item.category_id     nef_distance_restraint
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case 3.7
+   #
+save_
+#
+save__nef_distance_restraint.target_value_uncertainty
+   #
+
+   _item_description.description  "The uncertainty in the target value for the distance restraint value."
+   #
+   _item.name            "_nef_distance_restraint.target_value_uncertainty"
+   _item.category_id     nef_distance_restraint
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  0.4
+   #
+save_
+#
+save__nef_distance_restraint.lower_linear_limit
+   #
+
+   _item_description.description  "The lower limit for the linear distance restraint value."
+   #
+   _item.name            "_nef_distance_restraint.lower_linear_limit"
+   _item.category_id     nef_distance_restraint
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  2.0
+   #
+save_
+#
+save__nef_distance_restraint.lower_limit
+   #
+
+   _item_description.description  "The lower limit for the distance restraint value."
+   #
+   _item.name            "_nef_distance_restraint.lower_limit"
+   _item.category_id     nef_distance_restraint
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  2.5
+   #
+save_
+#
+save__nef_distance_restraint.upper_limit
+   #
+
+   _item_description.description  "The upper limit for the distance restraint value."
+   #
+   _item.name            "_nef_distance_restraint.upper_limit"
+   _item.category_id     nef_distance_restraint
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  4.2
+   #
+save_
+#
+save__nef_distance_restraint.upper_linear_limit
+   #
+
+   _item_description.description  "The upper limit for the linear distance restraint value."
+   #
+   _item.name            "_nef_distance_restraint.upper_linear_limit"
+   _item.category_id     nef_distance_restraint
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  4.7
+   #
+save_
+#
+
+#
+#                  nef_dihedral_restraint_list
+#
+
+
+
+save_nef_dihedral_restraint_list
+   #
+
+   _category.description     "The data items in the NEF_DIHEDRAL_RESTRAINT_LIST category provide additional details about the dihedral restraint list."
+   _category.id              nef_dihedral_restraint_list
+   _category.mandatory_code  no
+   #
+   _category_group.id  nef_group
+   #   #
+   loop_
+   _category_key.name
+     "_nef_dihedral_restraint_list.sf_framecode"  
+   #
+   _category_examples.detail  "Example 1"
+   _category_examples.case    
+;   _nef_dihedral_restraint_list.sf_category     nef_dihedral_restraint_list
+   _nef_dihedral_restraint_list.sf_framecode    dihedral_constraint_list
+   _nef_dihedral_restraint_list.potential_type  unknown
+;
+
+   #
+save_
+#
+save__nef_dihedral_restraint_list.sf_category
+   #
+
+   _item_description.description  "An identifier for the saveframe category (type)"
+   #
+   _item.name            "_nef_dihedral_restraint_list.sf_category"
+   _item.category_id     nef_dihedral_restraint_list
+   _item.mandatory_code  yes
+   #
+   _item_type.code  idname
+   #
+   _item_examples.case  nef_dihedral_restraint_list
+   #
+save_
+#
+save__nef_dihedral_restraint_list.sf_framecode
+   #
+
+   _item_description.description  "An identifier for the saveframe"
+   #
+   _item.name            "_nef_dihedral_restraint_list.sf_framecode"
+   _item.category_id     nef_dihedral_restraint_list
+   _item.mandatory_code  yes
+   #
+   _item_type.code   nef_framecode
+   #
+   _item_examples.case  nef_dihedral_restraint_list_L2
+   #
+save_
+#
+save__nef_dihedral_restraint_list.potential_type
+   #
+
+   _item_description.description  'The potential type used to model the dihedral restraints.'
+
+   #
+   _item.name            "_nef_dihedral_restraint_list.potential_type"
+   _item.category_id     nef_dihedral_restraint_list
+   _item.mandatory_code  yes
+   #
+   _item_type.code  potential_type
+   #
+   _item_examples.case  parabolic
+   #
+save_
+#
+save__nef_dihedral_restraint_list.restraint_origin
+   #
+
+   _item_description.description  "The source of the restraints (e.g. 'noe', 'hbond', 'measured'."
+
+   #
+   _item.name            "_nef_dihedral_restraint_list.restraint_origin"
+   _item.category_id     nef_dihedral_restraint_list
+   _item.mandatory_code  no
+   #
+   _item_type.code  singleline
+   #
+   _item_examples.case  TALOS
+   #
+save_
+#
+save_nef_dihedral_restraint
+   #
+
+   _category.description     "The data items in the NEF_DIHEDRAL_RESTRAINT category records the list of dihedral restraints."
+   _category.id              nef_dihedral_restraint
+   _category.parent_category_id   nef_dihedral_restraint_list
+   _category.mandatory_code  no
+   #
+   _category_group.id  nef_group
+   #
+   _category_key.name  "_nef_dihedral_restraint.ordinal"
+   #
+   _category_examples.detail  "Example 1"
+   _category_examples.case    
+;  loop_
+    _nef_dihedral_restraint.ordinal
+    _nef_dihedral_restraint.restraint_id
+    _nef_dihedral_restraint.restraint_combination_id
+    _nef_dihedral_restraint.chain_code_1
+    _nef_dihedral_restraint.sequence_code_1
+    _nef_dihedral_restraint.residue_type_1
+    _nef_dihedral_restraint.atom_name_1
+    _nef_dihedral_restraint.chain_code_2
+    _nef_dihedral_restraint.sequence_code_2
+    _nef_dihedral_restraint.residue_type_2
+    _nef_dihedral_restraint.atom_name_2
+    _nef_dihedral_restraint.chain_code_3
+    _nef_dihedral_restraint.sequence_code_3
+    _nef_dihedral_restraint.residue_type_3
+    _nef_dihedral_restraint.atom_name_3
+    _nef_dihedral_restraint.chain_code_4
+    _nef_dihedral_restraint.sequence_code_4
+    _nef_dihedral_restraint.residue_type_4
+    _nef_dihedral_restraint.atom_name_4
+    _nef_dihedral_restraint.weight
+    _nef_dihedral_restraint.target_value
+    _nef_dihedral_restraint.target_value_uncertainty
+    _nef_dihedral_restraint.lower_linear_limit
+    _nef_dihedral_restraint.lower_limit
+    _nef_dihedral_restraint.upper_limit
+    _nef_dihedral_restraint.upper_linear_limit
+    _nef_dihedral_restraint.name
+
+1  1  .  A 21 ALA N  A 21 ALA CA  A 21 ALA  C  A 22 THR N 1.00 -50.0 5.0 .  -60.0 -40.0  . PSI
+2  1  .  A 21 ALA N  A 21 ALA CA  A 21 ALA  C  A 22 THR N 1.00 105.0 5.0 .   90.0 120.0  . PSI
+3  2  .  A 12 ALA C  A 22 THR N   A 22 THR CA  A 22 THR C 3.00 -50.0 8.0 .  -60.0 -40.0  . PHI
+4  3  1  A 23 LYS C  A 24 ASP N   A 24 ASP CA  A 24 ASP C 1.00 -50.0 5.0 .  -60.0 -40.0  . PHI
+5  3  1  A 24 ASP N  A 24 ASP CA  A 24 ASP  C  A 25 HIS N 1.00 105.0 5.0 .   90.0 120.0  . PSI
+6  4  2  A 15 GLY C  A 16 ASN N   A 16 ASN CA  A 16 ASN C 1.00 -50.0 5.0 .  -60.0 -40.0  . PHI
+7  4  2  A 16 ASN N  A 16 ASN CA  A 16 ASN  C  A 17 CYS N 1.00 105.0 5.0 .   90.0 120.0  . PSI
+8  4  3  A 15 GLY C  A 16 ASN N   A 16 ASN CA  A 16 ASN C 1.00 -80.0 5.0 .  -90.0 -70.0  . PHI
+9  4  3  A 16 ASN N  A 16 ASN CA  A 16 ASN  C  A 17 CYS N 1.00 155.0 5.0 .  140.0 170.0  . PSI
+stop_
+;
+   #
+save_
+
+save__nef_dihedral_restraint.ordinal
+   #
+
+   _item_description.description  "Line number for the restraint loop - not preserved when data are read."
+   #
+   _item.name            "_nef_dihedral_restraint.ordinal"
+   _item.category_id     nef_dihedral_restraint
+   _item.mandatory_code  yes
+   #
+   _item_type.code  int
+   #
+   _item_examples.case  1
+   #
+save_
+#
+save__nef_dihedral_restraint.restraint_id
+   #
+
+   _item_description.description  "The unique identifier for the dihedral restraint."
+   #
+   _item.name            "_nef_dihedral_restraint.restraint_id"
+   _item.category_id     nef_dihedral_restraint
+   _item.mandatory_code  yes
+   #
+   _item_type.code  int
+   #
+   _item_examples.case  1
+   #
+save_
+#
+save__nef_dihedral_restraint.restraint_combination_id
+   #
+
+   _item_description.description   
+; An identifier for a restraint item combination within a dihedral restraint.
+Restraint items with the same restraint_combination_id must be part of the same restraint.
+When calculating a restraint they are AND-ed together, while contributions with different
+restraint_combination_id (or none) are ORed.
+;
+   #
+   _item.name            "_nef_dihedral_restraint.restraint_combination_id"
+   _item.category_id     nef_dihedral_restraint
+   _item.mandatory_code  no
+   #
+   _item_type.code  int
+   #
+   _item_examples.case  1
+   #
+   _item_linked.parent_name  "_nef_dihedral_restraint.restraint_id"
+   _item_linked.child_name   "_nef_dihedral_restraint.restraint_combination_id"
+   #
+save_
+#
+save__nef_dihedral_restraint.chain_code_1
+   #
+
+   _item_description.description  "The author provided name for the first partner chain or ligand instance."
+   #
+   _item.name            "_nef_dihedral_restraint.chain_code_1"
+   _item.category_id     nef_dihedral_restraint
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  B
+   #
+save_
+#
+save__nef_dihedral_restraint.sequence_code_1
+   #
+
+   _item_description.description  "The author provided position for the first partner residue."
+   #
+   _item.name            "_nef_dihedral_restraint.sequence_code_1"
+   _item.category_id     nef_dihedral_restraint
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  20
+   #
+save_
+#
+save__nef_dihedral_restraint.residue_type_1
+   #
+
+   _item_description.description  "The author provided name for the first partner residue."
+   #
+   _item.name            "_nef_dihedral_restraint.residue_type_1"
+   _item.category_id     nef_dihedral_restraint
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  ALA
+   #
+save_
+#
+save__nef_dihedral_restraint.atom_name_1
+   #
+
+   _item_description.description  "The author provided name for the first partner atom."
+   #
+   _item.name            "_nef_dihedral_restraint.atom_name_1"
+   _item.category_id     nef_dihedral_restraint
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  N
+   #
+save_
+#
+save__nef_dihedral_restraint.chain_code_2
+   #
+
+   _item_description.description  "The author provided name for the second partner chain or ligand instance."
+   #
+   _item.name            "_nef_dihedral_restraint.chain_code_2"
+   _item.category_id     nef_dihedral_restraint
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  B
+   #
+save_
+#
+save__nef_dihedral_restraint.sequence_code_2
+   #
+
+   _item_description.description  "The author provided position for the second partner residue."
+   #
+   _item.name            "_nef_dihedral_restraint.sequence_code_2"
+   _item.category_id     nef_dihedral_restraint
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  20
+   #
+save_
+#
+save__nef_dihedral_restraint.residue_type_2
+   #
+
+   _item_description.description  "The author provided name for the second partner residue."
+   #
+   _item.name            "_nef_dihedral_restraint.residue_type_2"
+   _item.category_id     nef_dihedral_restraint
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  ALA
+   #
+save_
+#
+save__nef_dihedral_restraint.atom_name_2
+   #
+
+   _item_description.description  "The author provided name for the first partner atom."
+   #
+   _item.name            "_nef_dihedral_restraint.atom_name_2"
+   _item.category_id     nef_dihedral_restraint
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  CA
+   #
+save_
+#
+save__nef_dihedral_restraint.chain_code_3
+   #
+
+   _item_description.description  "The author provided name for the third partner chain or ligand instance."
+   #
+   _item.name            "_nef_dihedral_restraint.chain_code_3"
+   _item.category_id     nef_dihedral_restraint
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  B
+   #
+save_
+#
+save__nef_dihedral_restraint.sequence_code_3
+   #
+
+   _item_description.description  "The author provided position for the third partner residue."
+   #
+   _item.name            "_nef_dihedral_restraint.sequence_code_3"
+   _item.category_id     nef_dihedral_restraint
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  20
+   #
+save_
+#
+save__nef_dihedral_restraint.residue_type_3
+   #
+
+   _item_description.description  "The author provided name for the third partner residue."
+   #
+   _item.name            "_nef_dihedral_restraint.residue_type_3"
+   _item.category_id     nef_dihedral_restraint
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  ALA
+   #
+save_
+#
+save__nef_dihedral_restraint.atom_name_3
+   #
+
+   _item_description.description  "The author provided name for the third partner atom."
+   #
+   _item.name            "_nef_dihedral_restraint.atom_name_3"
+   _item.category_id     nef_dihedral_restraint
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  C
+   #
+save_
+#
+save__nef_dihedral_restraint.chain_code_4
+   #
+
+   _item_description.description  "The author provided name for the fourth partner chain or ligand instance."
+   #
+   _item.name            "_nef_dihedral_restraint.chain_code_4"
+   _item.category_id     nef_dihedral_restraint
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  B
+   #
+save_
+#
+save__nef_dihedral_restraint.sequence_code_4
+   #
+
+   _item_description.description  "The author provided position for the fourth partner residue."
+   #
+   _item.name            "_nef_dihedral_restraint.sequence_code_4"
+   _item.category_id     nef_dihedral_restraint
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  21
+   #
+save_
+#
+save__nef_dihedral_restraint.residue_type_4
+   #
+
+   _item_description.description  "The author provided name for the fourth partner residue."
+   #
+   _item.name            "_nef_dihedral_restraint.residue_type_4"
+   _item.category_id     nef_dihedral_restraint
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  TRP
+   #
+save_
+#
+save__nef_dihedral_restraint.atom_name_4
+   #
+
+   _item_description.description  "The author provided name for the fourth partner atom."
+   #
+   _item.name            "_nef_dihedral_restraint.atom_name_4"
+   _item.category_id     nef_dihedral_restraint
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  N
+   #
+save_
+#
+save__nef_dihedral_restraint.weight
+   #
+
+   _item_description.description  "The weighting value applied to this dihedral restraint."
+   #
+   _item.name            "_nef_dihedral_restraint.weight"
+   _item.category_id     nef_dihedral_restraint
+   _item.mandatory_code  yes
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  1.0
+   #
+save_
+#
+#
+save__nef_dihedral_restraint.target_value
+   #
+
+   _item_description.description  "The target value for this dihedral restraint."
+   #
+   _item.name            "_nef_dihedral_restraint.target_value"
+   _item.category_id     nef_dihedral_restraint
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case 53.5
+   #
+save_
+#
+save__nef_dihedral_restraint.target_value_uncertainty
+   #
+
+   _item_description.description  "The uncertainty in the target value for this dihedral restraint."
+   #
+   _item.name            "_nef_dihedral_restraint.target_value_uncertainty"
+   _item.category_id     nef_dihedral_restraint
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  4.5
+   #
+save_
+#
+save__nef_dihedral_restraint.lower_linear_limit
+   #
+
+   _item_description.description  "The lower limit for the linear dihedral restraint value."
+   #
+   _item.name            "_nef_dihedral_restraint.lower_linear_limit"
+   _item.category_id     nef_dihedral_restraint
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  43.5
+   #
+save_
+#
+save__nef_dihedral_restraint.lower_limit
+   #
+
+   _item_description.description  "The lower limit for the dihedral restraint value."
+   #
+   _item.name            "_nef_dihedral_restraint.lower_limit"
+   _item.category_id     nef_dihedral_restraint
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  48.5
+   #
+save_
+#
+save__nef_dihedral_restraint.upper_limit
+   #
+
+   _item_description.description  "The upper limit for the dihedral restraint value."
+   #
+   _item.name            "_nef_dihedral_restraint.upper_limit"
+   _item.category_id     nef_dihedral_restraint
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  58.5
+   #
+save_
+#
+save__nef_dihedral_restraint.upper_linear_limit
+   #
+
+   _item_description.description  "The upper limit for the linear dihedral restraint value."
+   #
+   _item.name            "_nef_dihedral_restraint.upper_linear_limit"
+   _item.category_id     nef_dihedral_restraint
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  63.5
+   #
+save_
+#
+save__nef_dihedral_restraint.name
+   #
+
+   _item_description.description  "The author provided name for the dihedral restraint."
+   #
+   _item.name            "_nef_dihedral_restraint.name"
+   _item.category_id     nef_dihedral_restraint
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   loop_
+     _item_examples.case  
+     PHI
+     CHI1
+     stop_
+   #
+save_
+#
+#
+save_nef_rdc_restraint_list
+   #
+
+   _category.description     "The data items in the NEF_RDC_RESTRAINT_LIST category records additional details for the list of residual dipolar coupling restraints."
+   _category.id              nef_rdc_restraint_list
+   _category.mandatory_code  no
+   #
+   _category_group.id  nef_group
+   #   #
+   loop_
+   _category_key.name
+     "_nef_rdc_restraint_list.sf_framecode"  
+   #
+   _category_examples.detail  "Example 1"
+   _category_examples.case    
+;   _nef_rdc_restraint_list.sf_category           nef_rdc_restraint_list
+   _nef_rdc_restraint_list.sf_framecode          nef_rdc_restraint_list:1.Rdc,4
+   _nef_rdc_restraint_list.potential_type        log-harmonic
+;
+
+   #
+save_
+save__nef_rdc_restraint_list.sf_category
+   #
+
+   _item_description.description  "An identifier for the saveframe category (type)"
+   #
+   _item.name            "_nef_rdc_restraint_list.sf_category"
+   _item.category_id     nef_rdc_restraint_list
+   _item.mandatory_code  yes
+   #
+   _item_type.code  idname
+   #
+   _item_examples.case  nef_rdc_restraint_list
+   #
+save_
+#
+save__nef_rdc_restraint_list.sf_framecode
+   #
+
+   _item_description.description  "An identifier for the saveframe"
+   #
+   _item.name            "_nef_rdc_restraint_list.sf_framecode"
+   _item.category_id     nef_rdc_restraint_list
+   _item.mandatory_code  yes
+   #
+   _item_type.code nef_framecode
+   #
+   _item_examples.case  nef_rdc_restraint_list_medium2
+   #
+save_
+#
+save__nef_rdc_restraint_list.potential_type
+   #
+
+   _item_description.description  'The potential type used to model the residual dipolar coupling restraints.'
+   #
+   _item.name            "_nef_rdc_restraint_list.potential_type"
+   _item.category_id     nef_rdc_restraint_list
+   _item.mandatory_code  yes
+   #
+   _item_type.code  potential_type
+   #
+   _item_examples.case  unknown
+   #
+save_
+#
+save__nef_rdc_restraint_list.restraint_origin
+   #
+
+   _item_description.description  "The source of the restraints (e.g. 'noe', 'hbond', 'measured'."
+
+   #
+   _item.name            "_nef_rdc_restraint_list.restraint_origin"
+   _item.category_id     nef_rdc_restraint_list
+   _item.mandatory_code  no
+   #
+   _item_type.code  singleline
+   #
+   _item_examples.case  measured
+   #
+save_
+#
+save__nef_rdc_restraint_list.tensor_magnitude
+   #
+
+   _item_description.description  "The magnitude orientational parameter for the tensor."
+   #
+   _item.name            "_nef_rdc_restraint_list.tensor_magnitude"
+   _item.category_id     nef_rdc_restraint_list
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  11.300
+   #
+save_
+#
+save__nef_rdc_restraint_list.tensor_rhombicity
+   #
+
+   _item_description.description  "The rhombicity orientational parameter for the tensor."
+   #
+   _item.name            "_nef_rdc_restraint_list.tensor_rhombicity"
+   _item.category_id     nef_rdc_restraint_list
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  0.067
+   #
+save_
+#
+save__nef_rdc_restraint_list.tensor_chain_code
+   #
+
+   _item_description.description  "The author provided identifier for a polymer chain or ligand instance for a dummy residue specifying the location and orientation of the tensor."
+   #
+   _item.name            "_nef_rdc_restraint_list.tensor_chain_code"
+   _item.category_id     nef_rdc_restraint_list
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  C
+   #
+save_
+#
+save__nef_rdc_restraint_list.tensor_sequence_code
+   #
+
+   _item_description.description  "The author provided position in polymer sequence for a dummy residue specifying the location and orientation of the tensor."
+   #
+   _item.name            "_nef_rdc_restraint_list.tensor_sequence_code"
+   _item.category_id     nef_rdc_restraint_list
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  900
+   #
+save_
+#
+save__nef_rdc_restraint_list.tensor_residue_type
+   #
+
+   _item_description.description  "The author provided residue code for a dummy residue specifying the location and orientation of the tensor."
+   #
+   _item.name            "_nef_rdc_restraint_list.tensor_residue_type"
+   _item.category_id     nef_rdc_restraint_list
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  TNSR
+   #
+save_
+#
+#
+save_nef_rdc_restraint
+   #
+
+   _category.description          "The data items in the NEF_RDC_RESTRAINT category records the list of residual dipolar coupling restraints."
+   _category.id                   nef_rdc_restraint
+   _category.parent_category_id   nef_rdc_restraint_list
+   _category.mandatory_code       no
+   #
+   _category_group.id             nef_group
+   #
+   _category_key.name             '_nef_rdc_restraint.ordinal'
+   #
+   _category_examples.detail      "Example 1"
+   _category_examples.case    
+;
+  loop_
+    _nef_rdc_restraint.ordinal
+    _nef_rdc_restraint.restraint_id
+    _nef_rdc_restraint.restraint_combination_id
+    _nef_rdc_restraint.chain_code_1
+    _nef_rdc_restraint.sequence_code_1
+    _nef_rdc_restraint.residue_type_1
+    _nef_rdc_restraint.atom_name_1
+    _nef_rdc_restraint.chain_code_2
+    _nef_rdc_restraint.sequence_code_2
+    _nef_rdc_restraint.residue_type_2
+    _nef_rdc_restraint.atom_name_2
+    _nef_rdc_restraint.weight
+    _nef_rdc_restraint.target_value
+    _nef_rdc_restraint.target_value_uncertainty
+    _nef_rdc_restraint.lower_linear_limit
+    _nef_rdc_restraint.lower_limit
+    _nef_rdc_restraint.upper_limit
+    _nef_rdc_restraint.upper_linear_limit
+    _nef_rdc_restraint.scale
+    _nef_rdc_restraint.distance_dependent
+
+    1  1 .  A  21  ALA  H  A  21  ALA  N  1.00 -5.2  0.33  .  .  .  .  1.0  false
+    2  2 .  A  22  THR  H  A  22  THR  N  1.00  3.1  0.40  .  .  .  .  1.0  false
+  stop_
+;
+
+   #
+save_
+#
+save__nef_rdc_restraint.ordinal
+   #
+
+   _item_description.description  "Line number for the restraint loop - not preserved when data are read."
+   #
+   _item.name            "_nef_rdc_restraint.ordinal"
+   _item.category_id     nef_rdc_restraint
+   _item.mandatory_code  yes
+   #
+   _item_type.code  int
+   #
+   _item_examples.case  1
+   #
+save_
+save__nef_rdc_restraint.restraint_id
+   #
+
+   _item_description.description  "A unique identifier for the residual dipolar coupling restraint."
+   #
+   _item.name            "_nef_rdc_restraint.restraint_id"
+   _item.category_id     nef_rdc_restraint
+   _item.mandatory_code  yes
+   #
+   _item_type.code  int
+   #
+   _item_examples.case  1
+   #
+save_
+save__nef_rdc_restraint.restraint_combination_id
+   #
+
+   _item_description.description  
+; An identifier for a restraint item combination within a dihedral restraint.
+Restraint items with the same restraint_combination_id must be part of the same restraint.
+When calculating a restraint they are AND-ed together, while contributions with different
+restraint_combination_id (or none) are ORed.
+;
+   #
+   _item.name            "_nef_rdc_restraint.restraint_combination_id"
+   _item.category_id     nef_rdc_restraint
+   _item.mandatory_code  no
+   #
+   _item_type.code  int
+   #
+   _item_examples.case  1
+   #
+save_
+#
+save__nef_rdc_restraint.chain_code_1
+   #
+
+   _item_description.description  "The author provided name for the first partner chain or ligand instance."
+   #
+   _item.name            "_nef_rdc_restraint.chain_code_1"
+   _item.category_id     nef_rdc_restraint
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  B
+   #
+save_
+save__nef_rdc_restraint.sequence_code_1
+   #
+
+   _item_description.description  "The author provided position for the first partner residue."
+   #
+   _item.name            "_nef_rdc_restraint.sequence_code_1"
+   _item.category_id     nef_rdc_restraint
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  20B
+   #
+save_
+#
+save__nef_rdc_restraint.residue_type_1
+   #
+
+   _item_description.description  "The author provided name for the first partner residue."
+   #
+   _item.name            "_nef_rdc_restraint.residue_type_1"
+   _item.category_id     nef_rdc_restraint
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  ALA
+   #
+save_
+#
+#
+save__nef_rdc_restraint.atom_name_1
+   #
+
+   _item_description.description  "The author provided name for the first partner atom."
+   #
+   _item.name            "_nef_rdc_restraint.atom_name_1"
+   _item.category_id     nef_rdc_restraint
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  N
+   #
+save_
+#
+save__nef_rdc_restraint.chain_code_2
+   #
+
+   _item_description.description  "The author provided name for the second partner chain or ligand instance."
+   #
+   _item.name            "_nef_rdc_restraint.chain_code_2"
+   _item.category_id     nef_rdc_restraint
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  B
+   #
+save_
+save__nef_rdc_restraint.sequence_code_2
+   #
+
+   _item_description.description  "The author provided position for the second partner residue."
+   #
+   _item.name            "_nef_rdc_restraint.sequence_code_2"
+   _item.category_id     nef_rdc_restraint
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  20
+   #
+save_
+#
+save__nef_rdc_restraint.residue_type_2
+   #
+
+   _item_description.description  "The author provided name for the second partner residue."
+   #
+   _item.name            "_nef_rdc_restraint.residue_type_2"
+   _item.category_id     nef_rdc_restraint
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  ALA
+   #
+save_
+#
+save__nef_rdc_restraint.atom_name_2
+   #
+
+   _item_description.description  "The author provided name for the second partner atom."
+   #
+   _item.name            "_nef_rdc_restraint.atom_name_2"
+   _item.category_id     nef_rdc_restraint
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  H
+   #
+save_
+#
+save__nef_rdc_restraint.weight
+   #
+
+   _item_description.description  "The weighting value applied to the residual dipolar coupling restraint."
+   #
+   _item.name            "_nef_rdc_restraint.weight"
+   _item.category_id     nef_rdc_restraint
+   _item.mandatory_code  yes
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  1.0
+   #
+save_
+#
+save__nef_rdc_restraint.target_value
+   #
+
+   _item_description.description  "The target value applied for this residual dipolar coupling restraint."
+   #
+   _item.name            "_nef_rdc_restraint.target_value"
+   _item.category_id     nef_rdc_restraint
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  -7.3
+   #
+save_
+#
+save__nef_rdc_restraint.target_value_uncertainty
+   #
+
+   _item_description.description  "The uncertainty in the target value applied for this residual dipolar coupling restraint."
+   #
+   _item.name            "_nef_rdc_restraint.target_value_uncertainty"
+   _item.category_id     nef_rdc_restraint
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  0.5
+   #
+save_
+#
+save__nef_rdc_restraint.lower_linear_limit
+   #
+
+   _item_description.description  "The lower limit for the linear residual dipolar coupling restraint."
+   #
+   _item.name            "_nef_rdc_restraint.lower_linear_limit"
+   _item.category_id     nef_rdc_restraint
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  -9.3
+   #
+save_
+#
+save__nef_rdc_restraint.lower_limit
+   #
+
+   _item_description.description  "The lower limit for the residual dipolar coupling restraint."
+   #
+   _item.name            "_nef_rdc_restraint.lower_limit"
+   _item.category_id     nef_rdc_restraint
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  -7.8
+   #
+save_
+#
+save__nef_rdc_restraint.upper_limit
+   #
+
+   _item_description.description  "The upper limit for the residual dipolar coupling restraint."
+   #
+   _item.name            "_nef_rdc_restraint.upper_limit"
+   _item.category_id     nef_rdc_restraint
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  -6.8
+   #
+save_
+#
+save__nef_rdc_restraint.upper_linear_limit
+   #
+
+   _item_description.description  "The upper limit for the linear residual dipolar coupling restraint."
+   #
+   _item.name            "_nef_rdc_restraint.upper_linear_limit"
+   _item.category_id     nef_rdc_restraint
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  -5.3
+   #
+save_
+#
+save__nef_rdc_restraint.scale
+   #
+
+   _item_description.description  "The scale value applied to this residual dipolar coupling restraint."
+   #
+   _item.name            "_nef_rdc_restraint.scale"
+   _item.category_id     nef_rdc_restraint
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  1.0
+   #
+save_
+#
+save__nef_rdc_restraint.distance_dependent
+   #
+
+   _item_description.description  "This value shows whether the restraint value depends on a variable distance."
+   #
+   _item.name            "_nef_rdc_restraint.distance_dependent"
+   _item.category_id     nef_rdc_restraint
+   _item.mandatory_code  no
+   #
+   _item_type.code  boolean
+   #
+   _item_examples.case  false
+   #
+save_
+#
+
+#
+#            nef_nmr_spectrum
+#
+
+save_nef_nmr_spectrum
+   #
+
+   _category.description     "The data items in the NEF_NMR_SPECTRUM category describe the details of spectrum including the associated shift list, dimensionality, and experiment type."
+   _category.id              nef_nmr_spectrum
+   _category.mandatory_code  no
+   #
+   _category_group.id  nef_group
+   #   #
+   loop_
+   _category_key.name
+     "_nef_nmr_spectrum.sf_framecode"  
+   #
+   _category_examples.detail  "Example 1"
+   _category_examples.case    
+;   _nef_nmr_spectrum.sf_category                nef_nmr_spectrum
+   _nef_nmr_spectrum.sf_framecode               nef_nmr_spectrum_alinoe_raw
+   _nef_nmr_spectrum.num_dimensions             3
+   _nef_nmr_spectrum.chemical_shift_list        nef_chemical_shift_list_1
+   _nef_nmr_spectrum.experiment_classification  H_H[C].through-space
+   _nef_nmr_spectrum.experiment_type             '13C NOESY-HSQC'
+;
+
+   #
+save_
+#
+save__nef_nmr_spectrum.sf_category
+   #
+
+   _item_description.description  "An identifier for the saveframe category (type)"
+   #
+   _item.name            "_nef_nmr_spectrum.sf_category"
+   _item.category_id     nef_nmr_spectrum
+   _item.mandatory_code  yes
+   #
+   _item_type.code  idname
+   #
+   _item_examples.case  nef_nmr_spectrum
+   #
+save_
+#
+save__nef_nmr_spectrum.sf_framecode
+   #
+
+   _item_description.description  "An identifier for the saveframe"
+   #
+   _item.name            "_nef_nmr_spectrum.sf_framecode"
+   _item.category_id     nef_nmr_spectrum
+   _item.mandatory_code  yes
+   #
+   _item_type.code nef_framecode
+   #
+   _item_examples.case  nef_nmr_spectrum_alinoe_raw
+   #
+save_
+#
+#
+save__nef_nmr_spectrum.num_dimensions
+   #
+
+   _item_description.description  "The dimensionality of the NMR experiment related to this data set."
+   #
+   _item.name            "_nef_nmr_spectrum.num_dimensions"
+   _item.category_id     nef_nmr_spectrum
+   _item.mandatory_code  no
+   #
+   _item_type.code  int
+   #
+   _item_examples.case  3
+   #
+save_
+#
+save__nef_nmr_spectrum.chemical_shift_list
+   #
+
+   _item_description.description  "An identifier for the chemical shift list that specificaly matches this spectrum"
+   #
+   _item.name            "_nef_nmr_spectrum.chemical_shift_list"
+   _item.category_id     nef_nmr_spectrum
+   _item.mandatory_code  no
+   #
+   _item_type.code nef_framecode
+   #
+   _item_examples.case  nef_chemical_shift_list_1
+   #
+save_
+#
+save__nef_nmr_spectrum.experiment_classification
+   #
+
+   _item_description.description  "The NMR experiment classification string, in CCPN nomenclature, related to this data set."
+   #
+   _item.name            "_nef_nmr_spectrum.experiment_classification"
+   _item.category_id     nef_nmr_spectrum
+   _item.mandatory_code  no
+   #
+   _item_type.code  singleline
+   #
+   _item_examples.case  H_H[C].through-space
+   #
+save_
+#
+save__nef_nmr_spectrum.experiment_type
+   #
+
+   _item_description.description  "The NMR experiment type related to this data set."
+   #
+   _item.name            "_nef_nmr_spectrum.experiment_type"
+   _item.category_id     nef_nmr_spectrum
+   _item.mandatory_code  no
+   #
+   _item_type.code  singleline
+   #
+   _item_examples.case  13C-NOESY-HSQC
+   #
+save_
+#
+save_nef_spectrum_dimension
+   #
+
+   _category.description          "The data items in the NEF_SPECTRUM_DIMENSION category the details labeling and data collection for each dimension of the spectrum."
+   _category.id                   nef_spectrum_dimension
+   _category.parent_category_id   nef_nmr_spectrum
+   _category.mandatory_code       yes
+   #
+   _category_group.id             nef_group
+   #
+   _category_key.name             "_nef_spectrum_dimension.dimension_id"
+   #
+   _category_examples.detail  "Example 1"
+   _category_examples.case    
+;   loop_
+      _nef_spectrum_dimension.dimension_id
+      _nef_spectrum_dimension.axis_unit
+      _nef_spectrum_dimension.axis_code
+      _nef_spectrum_dimension.spectrometer_frequency
+      _nef_spectrum_dimension.spectral_width
+      _nef_spectrum_dimension.value_first_point
+      _nef_spectrum_dimension.folding
+      _nef_spectrum_dimension.absolute_peak_positions
+      _nef_spectrum_dimension.is_acquisition
+     1   ppm   1H    500.0         13.312               11.428   circular   true   true     
+     2   ppm   13C   125.7367377   203.600              201.80   circular   true   false    
+     3   ppm   1H    500.0         13.312               11.428   circular   true   false
+;
+
+   #
+save_
+#
+save__nef_spectrum_dimension.dimension_id
+   #
+
+   _item_description.description  "The index for the dimension. "
+   #
+   _item.name            "_nef_spectrum_dimension.dimension_id"
+   _item.category_id     nef_spectrum_dimension
+   _item.mandatory_code  yes
+   #
+   _item_type.code  int
+   #
+   _item_examples.case  1
+   #
+save_
+#
+save__nef_spectrum_dimension.axis_unit
+   #
+
+   _item_description.description  "The units for data collection."
+   #
+   _item.name            "_nef_spectrum_dimension.axis_unit"
+   _item.category_id     nef_spectrum_dimension
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  ppm
+   #
+save_
+#
+save__nef_spectrum_dimension.axis_code
+   #
+
+   _item_description.description  
+;A code identifying this axis 
+- for normal shift dimensions the isotope code.
+- for time axes 'delay'
+;
+   #
+   _item.name            "_nef_spectrum_dimension.axis_code"
+   _item.category_id     nef_spectrum_dimension
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  1H
+   #
+save_
+#
+save__nef_spectrum_dimension.spectrometer_frequency
+   #
+
+   _item_description.description  "The spectrometer frequency for data collection in MHz, as used to calculate folding."
+   #
+   _item.name            "_nef_spectrum_dimension.spectrometer_frequency"
+   _item.category_id     nef_spectrum_dimension
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  500.139
+   #
+save_
+#
+save__nef_spectrum_dimension.spectral_width
+   #
+
+   _item_description.description  "The spectral width for data collection in units of axis_unit."
+   #
+   _item.name            "_nef_spectrum_dimension.spectral_width"
+   _item.category_id     nef_spectrum_dimension
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  10.4
+   #
+save_
+#
+save__nef_spectrum_dimension.value_first_point
+   #
+
+   _item_description.description
+; The value of the first point collected along this dimension, 
+before any truncation, in units of axis_unit.
+;
+   #
+   _item.name            "_nef_spectrum_dimension.value_first_point"
+   _item.category_id     nef_spectrum_dimension
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  9.810
+   #
+save_
+#
+save__nef_spectrum_dimension.folding
+   #
+
+   _item_description.description  "A flag for the folding that applies to this data collection."
+   #
+   _item.name            "_nef_spectrum_dimension.folding"
+   _item.category_id     nef_spectrum_dimension
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  circular
+   #
+   loop_
+     _item_enumeration.value
+     circular
+     mirror
+     none
+   stop_
+save_
+#
+save__nef_spectrum_dimension.absolute_peak_positions
+   #
+
+   _item_description.description  
+;A flag determining whether peak positions are given as absolute_peak_positions
+- If true, peaks are shown at correct unaliased) positions whether this is within the acquisition window or not
+- If false, peaks are shown in the acquisition window, whether this is the correct value or not
+;
+   #
+   _item.name            "_nef_spectrum_dimension.absolute_peak_positions"
+   _item.category_id     nef_spectrum_dimension
+   _item.mandatory_code  no
+   #
+   _item_type.code  boolean
+   #
+   _item_examples.case  true
+   #
+save_
+#
+save__nef_spectrum_dimension.is_acquisition
+   #
+
+   _item_description.description  "Is this the acuisition dimension for the data collection?."
+   #
+   _item.name            "_nef_spectrum_dimension.is_acquisition"
+   _item.category_id     nef_spectrum_dimension
+   _item.mandatory_code  no
+   #
+   _item_type.code  boolean
+   #
+   _item_examples.case  false
+   #
+save_
+#
+save_nef_spectrum_dimension_transfer
+   #
+
+   _category.description          "The data items in the NEF_SPECTRUM_DIMENSION_TRANSFER category describe the magnetisation transfer between dimensions."
+   _category.id                   nef_spectrum_dimension_transfer
+   _category.parent_category_id   nef_nmr_spectrum
+   _category.mandatory_code       true
+   #
+   _category_group.id             nef_group
+   #   #
+   loop_
+   _category_key.name
+     "_nef_spectrum_dimension_transfer.dimension_1"  
+     "_nef_spectrum_dimension_transfer.dimension_2"  
+   #
+   _category_examples.detail  "Example 1"
+   _category_examples.case    
+;   loop_
+      _nef_spectrum_dimension_transfer.dimension_1
+      _nef_spectrum_dimension_transfer.dimension_2
+      _nef_spectrum_dimension_transfer.transfer_type
+      _nef_spectrum_dimension_transfer.is_indirect
+     1   2   onebond         false    
+     1   3   through-space   false    
+;
+
+   #
+save_
+#
+save__nef_spectrum_dimension_transfer.dimension_1
+   #
+
+   _item_description.description  "The identifier for the first dimension in the transfer pair."
+   #
+   _item.name            "_nef_spectrum_dimension_transfer.dimension_1"
+   _item.category_id     nef_spectrum_dimension_transfer
+   _item.mandatory_code  yes
+   #
+   _item_type.code  int
+   #
+   _item_examples.case  1
+   #
+   _item_linked.parent_name  "_nef_spectrum_dimension.dimension_id"
+   _item_linked.child_name   "_nef_spectrum_dimension_transfer.dimension_1"
+   #
+save_
+#
+save__nef_spectrum_dimension_transfer.dimension_2
+   #
+
+   _item_description.description  "The identifier for the second dimension in the transfer pair."
+   #
+   _item.name            "_nef_spectrum_dimension_transfer.dimension_2"
+   _item.category_id     nef_spectrum_dimension_transfer
+   _item.mandatory_code  yes
+   #
+   _item_type.code  int
+   #
+   _item_examples.case  2
+   #
+   _item_linked.parent_name  "_nef_spectrum_dimension.dimension_id"
+   _item_linked.child_name   "_nef_spectrum_dimension_transfer.dimension_2"
+   #
+save_
+#
+save__nef_spectrum_dimension_transfer.transfer_type
+   #
+
+   _item_description.description
+; The type of magnetisation transfer between spectrum dimensions. Allowed values are:
+- onebond:             Any transfer that connects only directly bonded atoms in this experiment
+- jcoupling:           Transfer via direct J coupling over one or more bonds
+- jmultibond:          Transfer via direct J coupling over multiple bonds
+- relayed:             Transfer via multiple successive J coupling steps (TOCSY, relay, ...)
+- relayed-alternate:   Relayed transfer, where peaks from an odd resp. even number of transfer steps have opposite sign
+- through-space:       Any transfer that does not go through the covalent bonded skeleton (NOESY, ROESY, ... but also J coupling through hydrogen bonds)
+;
+
+   #
+   _item.name            "_nef_spectrum_dimension_transfer.transfer_type"
+   _item.category_id     nef_spectrum_dimension_transfer
+   _item.mandatory_code  yes
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  onebond
+   
+   loop_
+   _item_enumeration.value
+     onebond
+     jcoupling
+     jmultibond
+     relayed
+     relayed-alternate
+     through-space
+   stop_
+   
+   #   #
+save_
+#
+save__nef_spectrum_dimension_transfer.is_indirect
+   #
+
+   _item_description.description  
+;A flag defining whether the magnetisation transfer is indirect,
+i.e. relayed through other, more short-range transfer steps in addition to the main transfer_type..
+;
+   #
+   _item.name            "_nef_spectrum_dimension_transfer.is_indirect"
+   _item.category_id     nef_spectrum_dimension_transfer
+   _item.mandatory_code  no
+   #
+   _item_type.code  boolean
+   #
+   _item_examples.case  false
+   #
+save_
+#
+save_nef_peak
+   #
+
+   _category.description          "The data items in the NEF_PEAK category enumerates the list of spectrum peaks and associated assignments."
+   _category.id                   nef_peak
+   _category.parent_category_id   nef_nmr_spectrum
+   _category.mandatory_code       no
+   #
+   _category_group.id             nef_group
+   #
+   _category_key.name             "_nef_peak.ordinal"
+   #
+   loop_
+      _category_examples.detail     
+      _category_examples.case    
+       "Example 1" 
+;
+  loop_
+
+      _nef_peak.ordinal
+      _nef_peak.peak_id
+      _nef_peak.volume
+      _nef_peak.volume_uncertainty
+      _nef_peak.height
+      _nef_peak.height_uncertainty
+      _nef_peak.position_1
+      _nef_peak.position_uncertainty_1
+      _nef_peak.position_2
+      _nef_peak.position_uncertainty_2
+      _nef_peak.position_3
+      _nef_peak.position_uncertainty_3
+      _nef_peak.chain_code_1
+      _nef_peak.sequence_code_1
+      _nef_peak.residue_type_1
+      _nef_peak.atom_name_1
+      _nef_peak.chain_code_2
+      _nef_peak.sequence_code_2
+      _nef_peak.residue_type_2
+      _nef_peak.atom_name_2
+      _nef_peak.chain_code_3
+      _nef_peak.sequence_code_3
+      _nef_peak.residue_type_3
+      _nef_peak.atom_name_3
+
+  #key: ordinal
+
+ 1  1 7.3E7 5.1E6 3.3E7 1.1E6  3.2 0.05 119.5 0.5 8.3 0.03 A 19 LEU HBY A 17 GLN N   A 17 GLN H
+ 2  1 7.3E7 5.1E6 3.3E7 1.1E6  3.2 0.05 119.5 0.5 8.3 0.03 A 20 CYS HBX A 17 GLN N   A 17 GLN H
+ 3  1 7.3E7 5.1E6 3.3E7 1.1E6  3.2 0.05 119.5 0.5 8.3 0.03 A 19 LEU HBY A 19 TYR N   A 19 TYR H
+ 4  1 7.3E7 5.1E6 3.3E7 1.1E6  3.2 0.05 119.5 0.5 8.3 0.03 A 20 CYS HBX A 19 TYR N   A 19 TYR H
+ 5  1 7.3E7 5.1E6 3.3E7 1.1E6  3.2 0.05 119.5 0.5 8.3 0.03 A 14 TRP HB3 A 18 PHE N   A 18 PHE H
+ 6  3 5.4E7 7.3E6 3.4E7 5.3E6  4.4 0.05 106.5 0.5 7.8 0.03 .  .   .   . A 15 GLY N   A 15 GLY H
+ 7  4 8.8E7 1.3E7 4.8E7 3.3E6  3.2 0.05 135.6 0.5 9.9 0.03 A 14 TRP HB3 A 14 TRP NE1 A 14 TRP HE1
+ 8  5 8.8E7 1.3E7 5.8E7 2.3E7  3.4 0.05 135.6 0.5 9.9 0.03 A 14 TRP HB2 A 14 TRP NE1 A 14 TRP HE1
+ 9  5 8.8E7 1.3E7 5.8E7 2.3E7  3.4 0.05 135.6 0.5 9.9 0.03 A 24 ASP HBY A 14 TRP NE1 A 14 TRP HE1
+10  7 5.9E7 7.1E6 2.9E7 6.1E6  1.7 0.05 118.3 0.5 9.1 0.03 E 6B SER   . X @5 GLX N   X @5 GLX H
+  stop_
+;
+       "Example 2"
+;   loop_
+      _nef_peak.ordinal
+      _nef_peak.peak_id
+      _nef_peak.volume
+      _nef_peak.volume_uncertainty
+      _nef_peak.height
+      _nef_peak.height_uncertainty
+      _nef_peak.position_1
+      _nef_peak.position_uncertainty_1
+      _nef_peak.position_2
+      _nef_peak.position_uncertainty_2
+      _nef_peak.position_3
+      _nef_peak.position_uncertainty_3
+      _nef_peak.position_4
+      _nef_peak.position_uncertainty_4
+      _nef_peak.position_5
+      _nef_peak.position_uncertainty_5
+      _nef_peak.position_6
+      _nef_peak.position_uncertainty_6
+      _nef_peak.position_7
+      _nef_peak.position_uncertainty_7
+      _nef_peak.position_8
+      _nef_peak.position_uncertainty_8
+      _nef_peak.position_9
+      _nef_peak.position_uncertainty_9
+      _nef_peak.position_10
+      _nef_peak.position_uncertainty_10
+      _nef_peak.position_11
+      _nef_peak.position_uncertainty_11
+      _nef_peak.position_12
+      _nef_peak.position_uncertainty_12
+      _nef_peak.position_13
+      _nef_peak.position_uncertainty_13
+      _nef_peak.position_14
+      _nef_peak.position_uncertainty_14
+      _nef_peak.position_15
+      _nef_peak.position_uncertainty_15
+      _nef_peak.chain_code_1
+      _nef_peak.sequence_code_1
+      _nef_peak.residue_type_1
+      _nef_peak.atom_name_1
+      _nef_peak.chain_code_2
+      _nef_peak.sequence_code_2
+      _nef_peak.residue_type_2
+      _nef_peak.atom_name_2
+      _nef_peak.chain_code_3
+      _nef_peak.sequence_code_3
+      _nef_peak.residue_type_3
+      _nef_peak.atom_name_3
+      _nef_peak.chain_code_4
+      _nef_peak.sequence_code_4
+      _nef_peak.residue_type_4
+      _nef_peak.atom_name_4
+      _nef_peak.chain_code_5
+      _nef_peak.sequence_code_5
+      _nef_peak.residue_type_5
+      _nef_peak.atom_name_5
+      _nef_peak.chain_code_6
+      _nef_peak.sequence_code_6
+      _nef_peak.residue_type_6
+      _nef_peak.atom_name_6
+      _nef_peak.chain_code_7
+      _nef_peak.sequence_code_7
+      _nef_peak.residue_type_7
+      _nef_peak.atom_name_7
+      _nef_peak.chain_code_8
+      _nef_peak.sequence_code_8
+      _nef_peak.residue_type_8
+      _nef_peak.atom_name_8
+      _nef_peak.chain_code_9
+      _nef_peak.sequence_code_9
+      _nef_peak.residue_type_9
+      _nef_peak.atom_name_9
+      _nef_peak.chain_code_10
+      _nef_peak.sequence_code_10
+      _nef_peak.residue_type_10
+      _nef_peak.atom_name_10
+      _nef_peak.chain_code_11
+      _nef_peak.sequence_code_11
+      _nef_peak.residue_type_11
+      _nef_peak.atom_name_11
+      _nef_peak.chain_code_12
+      _nef_peak.sequence_code_12
+      _nef_peak.residue_type_12
+      _nef_peak.atom_name_12
+      _nef_peak.chain_code_13
+      _nef_peak.sequence_code_13
+      _nef_peak.residue_type_13
+      _nef_peak.atom_name_13
+      _nef_peak.chain_code_14
+      _nef_peak.sequence_code_14
+      _nef_peak.residue_type_14
+      _nef_peak.atom_name_14
+      _nef_peak.chain_code_15
+      _nef_peak.sequence_code_15
+      _nef_peak.residue_type_15
+      _nef_peak.atom_name_15
+
+
+ 1  1 7.3E7 5.1E6 3.3E7 1.1E6  
+ 7.2 0.05 119.5 0.4 28.3 0.3 172.2 0.5 58.5 0.4 32.3 0.4 22.2 0.5 58.5 0.4 32.3 0.4 22.2 0.5 58.5 0.4 32.3 0.4 22.2 0.5 58.5 0.4 32.3 0.4  
+ A 19 LEU HN A 19 LEU N A 18 GLN C  A 19 LEU CA A 19 LEU CB A 19 LEU CG  A 19 LEU CD1 A 19 LEU CD2 A 19 LEU CG A 19 LEU CA A 19 LEU CB A 19 LEU CG A 18 GLN CA A 18 GLN CB A 18 GLN CG 
+  stop_
+;
+
+   #
+save_
+#
+save__nef_peak.ordinal
+   #
+   
+   _item_description.description  "Line number for the peak loop - not preserved when data are read."
+   #
+   _item.name            "_nef_peak.ordinal"
+   _item.category_id     nef_peak
+   _item.mandatory_code  yes
+   #
+   _item_type.code  int
+   #
+   _item_examples.case  1
+   #
+save_
+#
+save__nef_peak.peak_id
+   #
+
+   _item_description.description  "The unique identifier for the peak."
+   #
+   _item.name            "_nef_peak.peak_id"
+   _item.category_id     nef_peak
+   _item.mandatory_code  yes
+   #
+   _item_type.code  int
+   #
+   _item_examples.case  1
+   #
+save_
+#
+save__nef_peak.volume
+   #
+
+   _item_description.description  "The peak volume. "
+   #
+   _item.name            "_nef_peak.volume"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  7.3E7
+   #
+save_
+#
+save__nef_peak.volume_uncertainty
+   #
+
+   _item_description.description  "The uncertainty in peak volume. "
+   #
+   _item.name            "_nef_peak.volume_uncertainty"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  9.0E5
+   #
+save_
+#
+save__nef_peak.height
+   #
+
+   _item_description.description  "The peak height. "
+   #
+   _item.name            "_nef_peak.height"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  2.6E6
+   #
+save_
+#
+save__nef_peak.height_uncertainty
+   #
+
+   _item_description.description  "The uncertainty in the peak height. "
+   #
+   _item.name            "_nef_peak.height_uncertainty"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  8.1E5
+   #
+save_
+#
+save__nef_peak.position_1
+   #
+
+   _item_description.description  "The peak position along dimension 1 of the NMR spectrum."
+   #
+   _item.name            "_nef_peak.position_1"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  11.3
+   #
+save_
+#
+save__nef_peak.position_uncertainty_1
+   #
+
+   _item_description.description  "The uncertainty in the peak position along dimension 1 of the NMR spectrum."
+   #
+   _item.name            "_nef_peak.position_uncertainty_1"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  0.2
+   #
+save_
+#
+save__nef_peak.position_2
+   #
+
+   _item_description.description  "The peak position along dimension 2 of the NMR spectrum."
+   #
+   _item.name            "_nef_peak.position_2"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  11.3
+   #
+save_
+#
+save__nef_peak.position_uncertainty_2
+   #
+
+   _item_description.description  "The uncertainty in the peak position along dimension 2 of the NMR spectrum."
+   #
+   _item.name            "_nef_peak.position_uncertainty_2"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  0.2
+   #
+save_
+#
+save__nef_peak.position_3
+   #
+
+   _item_description.description  "The peak position along dimension 3 of the NMR spectrum."
+   #
+   _item.name            "_nef_peak.position_3"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  11.3
+   #
+save_
+#
+save__nef_peak.position_uncertainty_3
+   #
+
+   _item_description.description  "The uncertainty in the peak position along dimension 3 of the NMR spectrum."
+   #
+   _item.name            "_nef_peak.position_uncertainty_3"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  0.2
+   #
+save_
+#
+save__nef_peak.position_4
+   #
+
+   _item_description.description  "The peak position along dimension 4 of the NMR spectrum."
+   #
+   _item.name            "_nef_peak.position_4"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  11.3
+   #
+save_
+#
+save__nef_peak.position_uncertainty_4
+   #
+
+   _item_description.description  "The uncertainty in the peak position along dimension 4 of the NMR spectrum."
+   #
+   _item.name            "_nef_peak.position_uncertainty_4"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  0.2
+   #
+save_
+#
+save__nef_peak.position_5
+   #
+
+   _item_description.description  "The peak position along dimension 5 of the NMR spectrum."
+   #
+   _item.name            "_nef_peak.position_5"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  11.3
+   #
+save_
+#
+save__nef_peak.position_uncertainty_5
+   #
+
+   _item_description.description  "The uncertainty in the peak position along dimension 5 of the NMR spectrum."
+   #
+   _item.name            "_nef_peak.position_uncertainty_5"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  0.2
+   #
+save_
+#
+save__nef_peak.position_6
+   #
+
+   _item_description.description  "The peak position along dimension 6 of the NMR spectrum."
+   #
+   _item.name            "_nef_peak.position_6"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  11.3
+   #
+save_
+#
+save__nef_peak.position_uncertainty_6
+   #
+
+   _item_description.description  "The uncertainty in the peak position along dimension 6 of the NMR spectrum."
+   #
+   _item.name            "_nef_peak.position_uncertainty_6"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  0.2
+   #
+save_
+#
+save__nef_peak.position_7
+   #
+
+   _item_description.description  "The peak position along dimension 7 of the NMR spectrum."
+   #
+   _item.name            "_nef_peak.position_7"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  11.3
+   #
+save_
+#
+save__nef_peak.position_uncertainty_7
+   #
+
+   _item_description.description  "The uncertainty in the peak position along dimension 7 of the NMR spectrum."
+   #
+   _item.name            "_nef_peak.position_uncertainty_7"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  0.2
+   #
+save_
+#
+save__nef_peak.position_8
+   #
+
+   _item_description.description  "The peak position along dimension 8 of the NMR spectrum."
+   #
+   _item.name            "_nef_peak.position_8"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  11.3
+   #
+save_
+#
+save__nef_peak.position_uncertainty_8
+   #
+
+   _item_description.description  "The uncertainty in the peak position along dimension 8 of the NMR spectrum."
+   #
+   _item.name            "_nef_peak.position_uncertainty_8"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  0.2
+   #
+save_
+#
+save__nef_peak.position_9
+   #
+
+   _item_description.description  "The peak position along dimension 9 of the NMR spectrum."
+   #
+   _item.name            "_nef_peak.position_9"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  11.3
+   #
+save_
+#
+save__nef_peak.position_uncertainty_9
+   #
+
+   _item_description.description  "The uncertainty in the peak position along dimension 9 of the NMR spectrum."
+   #
+   _item.name            "_nef_peak.position_uncertainty_9"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  0.2
+   #
+save_
+#
+save__nef_peak.position_10
+   #
+
+   _item_description.description  "The peak position along dimension 10 of the NMR spectrum."
+   #
+   _item.name            "_nef_peak.position_10"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  11.3
+   #
+save_
+#
+save__nef_peak.position_uncertainty_10
+   #
+
+   _item_description.description  "The uncertainty in the peak position along dimension 10 of the NMR spectrum."
+   #
+   _item.name            "_nef_peak.position_uncertainty_10"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  0.2
+   #
+save_
+#
+save__nef_peak.position_11
+   #
+
+   _item_description.description  "The peak position along dimension 11 of the NMR spectrum."
+   #
+   _item.name            "_nef_peak.position_11"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  11.3
+   #
+save_
+#
+save__nef_peak.position_uncertainty_11
+   #
+
+   _item_description.description  "The uncertainty in the peak position along dimension 11 of the NMR spectrum."
+   #
+   _item.name            "_nef_peak.position_uncertainty_11"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  0.2
+   #
+save_
+#
+save__nef_peak.position_12
+   #
+
+   _item_description.description  "The peak position along dimension 12 of the NMR spectrum."
+   #
+   _item.name            "_nef_peak.position_12"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  11.3
+   #
+save_
+#
+save__nef_peak.position_uncertainty_12
+   #
+
+   _item_description.description  "The uncertainty in the peak position along dimension 12 of the NMR spectrum."
+   #
+   _item.name            "_nef_peak.position_uncertainty_12"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  0.2
+   #
+save_
+#
+save__nef_peak.position_13
+   #
+
+   _item_description.description  "The peak position along dimension 13 of the NMR spectrum."
+   #
+   _item.name            "_nef_peak.position_13"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  11.3
+   #
+save_
+#
+save__nef_peak.position_uncertainty_13
+   #
+
+   _item_description.description  "The uncertainty in the peak position along dimension 13 of the NMR spectrum."
+   #
+   _item.name            "_nef_peak.position_uncertainty_13"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  0.2
+   #
+save_
+#
+save__nef_peak.position_14
+   #
+
+   _item_description.description  "The peak position along dimension 14 of the NMR spectrum."
+   #
+   _item.name            "_nef_peak.position_14"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  11.3
+   #
+save_
+#
+save__nef_peak.position_uncertainty_14
+   #
+
+   _item_description.description  "The uncertainty in the peak position along dimension 14 of the NMR spectrum."
+   #
+   _item.name            "_nef_peak.position_uncertainty_14"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  0.2
+   #
+save_
+#
+save__nef_peak.position_15
+   #
+
+   _item_description.description  "The peak position along dimension 15 of the NMR spectrum."
+   #
+   _item.name            "_nef_peak.position_15"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  11.3
+   #
+save_
+#
+save__nef_peak.position_uncertainty_15
+   #
+
+   _item_description.description  "The uncertainty in the peak position along dimension 15 of the NMR spectrum."
+   #
+   _item.name            "_nef_peak.position_uncertainty_15"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  float
+   #
+   _item_examples.case  0.2
+   #
+save_
+
+#
+save__nef_peak.chain_code_1
+   #
+
+   _item_description.description  "The author provided identifier for a polymer chain or ligand instance for the nuclear assignment associated with dimension 1 of the spectrum."
+   #
+   _item.name            "_nef_peak.chain_code_1"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  B
+   #
+save_
+save__nef_peak.sequence_code_1
+   #
+
+   _item_description.description  "The author provided identifier for the position in polymer sequence for the nuclear assignment associated with dimension 1 of the spectrum."
+   #
+   _item.name            "_nef_peak.sequence_code_1"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  20
+   #
+save_
+#
+save__nef_peak.residue_type_1
+   #
+
+   _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 1 of the spectrum."
+   #
+   _item.name            "_nef_peak.residue_type_1"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  ALA
+   #
+save_
+#
+#
+save__nef_peak.atom_name_1
+   #
+
+   _item_description.description  "The atom name for the nuclear assignment associated with dimension 1 of the spectrum."
+   #
+   _item.name            "_nef_peak.atom_name_1"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  HB1
+   #
+save_
+
+#
+save__nef_peak.chain_code_2
+   #
+
+   _item_description.description  "The author provided identifier for a polymer chain or ligand instance for the nuclear assignment associated with dimension 2 of the spectrum."
+   #
+   _item.name            "_nef_peak.chain_code_2"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  B
+   #
+save_
+save__nef_peak.sequence_code_2
+   #
+
+   _item_description.description  "The author provided identifier for the position in polymer sequence for the nuclear assignment associated with dimension 2 of the spectrum."
+   #
+   _item.name            "_nef_peak.sequence_code_2"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  20
+   #
+save_
+#
+save__nef_peak.residue_type_2
+   #
+
+   _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 2 of the spectrum."
+   #
+   _item.name            "_nef_peak.residue_type_2"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  ALA
+   #
+save_
+#
+#
+save__nef_peak.atom_name_2
+   #
+
+   _item_description.description  "The atom name for the nuclear assignment associated with dimension 2 of the spectrum."
+   #
+   _item.name            "_nef_peak.atom_name_2"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  HB1
+   #
+save_
+
+#
+save__nef_peak.chain_code_3
+   #
+
+   _item_description.description  "The author provided identifier for a polymer chain or ligand instance for the nuclear assignment associated with dimension 3 of the spectrum."
+   #
+   _item.name            "_nef_peak.chain_code_3"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  B
+   #
+save_
+save__nef_peak.sequence_code_3
+   #
+
+   _item_description.description  "The author provided identifier for the position in polymer sequence for the nuclear assignment associated with dimension 3 of the spectrum."
+   #
+   _item.name            "_nef_peak.sequence_code_3"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  20
+   #
+save_
+#
+save__nef_peak.residue_type_3
+   #
+
+   _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 3 of the spectrum."
+   #
+   _item.name            "_nef_peak.residue_type_3"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  ALA
+   #
+save_
+#
+#
+save__nef_peak.atom_name_3
+   #
+
+   _item_description.description  "The atom name for the nuclear assignment associated with dimension 3 of the spectrum."
+   #
+   _item.name            "_nef_peak.atom_name_3"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  HB1
+   #
+save_
+
+#
+save__nef_peak.chain_code_4
+   #
+
+   _item_description.description  "The author provided identifier for a polymer chain or ligand instance for the nuclear assignment associated with dimension 4 of the spectrum."
+   #
+   _item.name            "_nef_peak.chain_code_4"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  B
+   #
+save_
+save__nef_peak.sequence_code_4
+   #
+
+   _item_description.description  "The author provided identifier for the position in polymer sequence for the nuclear assignment associated with dimension 4 of the spectrum."
+   #
+   _item.name            "_nef_peak.sequence_code_4"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  20
+   #
+save_
+#
+save__nef_peak.residue_type_4
+   #
+
+   _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 4 of the spectrum."
+   #
+   _item.name            "_nef_peak.residue_type_4"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  ALA
+   #
+save_
+#
+#
+save__nef_peak.atom_name_4
+   #
+
+   _item_description.description  "The atom name for the nuclear assignment associated with dimension 4 of the spectrum."
+   #
+   _item.name            "_nef_peak.atom_name_4"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  HB1
+   #
+save_
+
+#
+save__nef_peak.chain_code_5
+   #
+
+   _item_description.description  "The author provided identifier for a polymer chain or ligand instance for the nuclear assignment associated with dimension 5 of the spectrum."
+   #
+   _item.name            "_nef_peak.chain_code_5"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  B
+   #
+save_
+save__nef_peak.sequence_code_5
+   #
+
+   _item_description.description  "The author provided identifier for the position in polymer sequence for the nuclear assignment associated with dimension 5 of the spectrum."
+   #
+   _item.name            "_nef_peak.sequence_code_5"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  20
+   #
+save_
+#
+save__nef_peak.residue_type_5
+   #
+
+   _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 5 of the spectrum."
+   #
+   _item.name            "_nef_peak.residue_type_5"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  ALA
+   #
+save_
+#
+#
+save__nef_peak.atom_name_5
+   #
+
+   _item_description.description  "The atom name for the nuclear assignment associated with dimension 5 of the spectrum."
+   #
+   _item.name            "_nef_peak.atom_name_5"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  HB1
+   #
+save_
+
+#
+save__nef_peak.chain_code_6
+   #
+
+   _item_description.description  "The author provided identifier for a polymer chain or ligand instance for the nuclear assignment associated with dimension 6 of the spectrum."
+   #
+   _item.name            "_nef_peak.chain_code_6"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  B
+   #
+save_
+save__nef_peak.sequence_code_6
+   #
+
+   _item_description.description  "The author provided identifier for the position in polymer sequence for the nuclear assignment associated with dimension 6 of the spectrum."
+   #
+   _item.name            "_nef_peak.sequence_code_6"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  20
+   #
+save_
+#
+save__nef_peak.residue_type_6
+   #
+
+   _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 6 of the spectrum."
+   #
+   _item.name            "_nef_peak.residue_type_6"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  ALA
+   #
+save_
+#
+#
+save__nef_peak.atom_name_6
+   #
+
+   _item_description.description  "The atom name for the nuclear assignment associated with dimension 6 of the spectrum."
+   #
+   _item.name            "_nef_peak.atom_name_6"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  HB1
+   #
+save_
+
+#
+save__nef_peak.chain_code_7
+   #
+
+   _item_description.description  "The author provided identifier for a polymer chain or ligand instance for the nuclear assignment associated with dimension 7 of the spectrum."
+   #
+   _item.name            "_nef_peak.chain_code_7"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  B
+   #
+save_
+save__nef_peak.sequence_code_7
+   #
+
+   _item_description.description  "The author provided identifier for the position in polymer sequence for the nuclear assignment associated with dimension 7 of the spectrum."
+   #
+   _item.name            "_nef_peak.sequence_code_7"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  20
+   #
+save_
+#
+save__nef_peak.residue_type_7
+   #
+
+   _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 7 of the spectrum."
+   #
+   _item.name            "_nef_peak.residue_type_7"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  ALA
+   #
+save_
+#
+#
+save__nef_peak.atom_name_7
+   #
+
+   _item_description.description  "The atom name for the nuclear assignment associated with dimension 7 of the spectrum."
+   #
+   _item.name            "_nef_peak.atom_name_7"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  HB1
+   #
+save_
+
+#
+save__nef_peak.chain_code_8
+   #
+
+   _item_description.description  "The author provided identifier for a polymer chain or ligand instance for the nuclear assignment associated with dimension 8 of the spectrum."
+   #
+   _item.name            "_nef_peak.chain_code_8"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  B
+   #
+save_
+save__nef_peak.sequence_code_8
+   #
+
+   _item_description.description  "The author provided identifier for the position in polymer sequence for the nuclear assignment associated with dimension 8 of the spectrum."
+   #
+   _item.name            "_nef_peak.sequence_code_8"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  20
+   #
+save_
+#
+save__nef_peak.residue_type_8
+   #
+
+   _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 8 of the spectrum."
+   #
+   _item.name            "_nef_peak.residue_type_8"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  ALA
+   #
+save_
+#
+#
+save__nef_peak.atom_name_8
+   #
+
+   _item_description.description  "The atom name for the nuclear assignment associated with dimension 8 of the spectrum."
+   #
+   _item.name            "_nef_peak.atom_name_8"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  HB1
+   #
+save_
+
+#
+save__nef_peak.chain_code_9
+   #
+
+   _item_description.description  "The author provided identifier for a polymer chain or ligand instance for the nuclear assignment associated with dimension 9 of the spectrum."
+   #
+   _item.name            "_nef_peak.chain_code_9"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  B
+   #
+save_
+save__nef_peak.sequence_code_9
+   #
+
+   _item_description.description  "The author provided identifier for the position in polymer sequence for the nuclear assignment associated with dimension 9 of the spectrum."
+   #
+   _item.name            "_nef_peak.sequence_code_9"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  20
+   #
+save_
+#
+save__nef_peak.residue_type_9
+   #
+
+   _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 9 of the spectrum."
+   #
+   _item.name            "_nef_peak.residue_type_9"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  ALA
+   #
+save_
+#
+#
+save__nef_peak.atom_name_9
+   #
+
+   _item_description.description  "The atom name for the nuclear assignment associated with dimension 9 of the spectrum."
+   #
+   _item.name            "_nef_peak.atom_name_9"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  HB1
+   #
+save_
+
+#
+save__nef_peak.chain_code_10
+   #
+
+   _item_description.description  "The author provided identifier for a polymer chain or ligand instance for the nuclear assignment associated with dimension 10 of the spectrum."
+   #
+   _item.name            "_nef_peak.chain_code_10"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  B
+   #
+save_
+save__nef_peak.sequence_code_10
+   #
+
+   _item_description.description  "The author provided identifier for the position in polymer sequence for the nuclear assignment associated with dimension 10 of the spectrum."
+   #
+   _item.name            "_nef_peak.sequence_code_10"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  20
+   #
+save_
+#
+save__nef_peak.residue_type_10
+   #
+
+   _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 10 of the spectrum."
+   #
+   _item.name            "_nef_peak.residue_type_10"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  ALA
+   #
+save_
+#
+#
+save__nef_peak.atom_name_10
+   #
+
+   _item_description.description  "The atom name for the nuclear assignment associated with dimension 10 of the spectrum."
+   #
+   _item.name            "_nef_peak.atom_name_10"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  HB1
+   #
+save_
+
+#
+save__nef_peak.chain_code_11
+   #
+
+   _item_description.description  "The author provided identifier for a polymer chain or ligand instance for the nuclear assignment associated with dimension 11 of the spectrum."
+   #
+   _item.name            "_nef_peak.chain_code_11"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  B
+   #
+save_
+save__nef_peak.sequence_code_11
+   #
+
+   _item_description.description  "The author provided identifier for the position in polymer sequence for the nuclear assignment associated with dimension 11 of the spectrum."
+   #
+   _item.name            "_nef_peak.sequence_code_11"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  20
+   #
+save_
+#
+save__nef_peak.residue_type_11
+   #
+
+   _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 11 of the spectrum."
+   #
+   _item.name            "_nef_peak.residue_type_11"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  ALA
+   #
+save_
+#
+#
+save__nef_peak.atom_name_11
+   #
+
+   _item_description.description  "The atom name for the nuclear assignment associated with dimension 11 of the spectrum."
+   #
+   _item.name            "_nef_peak.atom_name_11"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  HB1
+   #
+save_
+
+#
+save__nef_peak.chain_code_12
+   #
+
+   _item_description.description  "The author provided identifier for a polymer chain or ligand instance for the nuclear assignment associated with dimension 12 of the spectrum."
+   #
+   _item.name            "_nef_peak.chain_code_12"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  B
+   #
+save_
+save__nef_peak.sequence_code_12
+   #
+
+   _item_description.description  "The author provided identifier for the position in polymer sequence for the nuclear assignment associated with dimension 12 of the spectrum."
+   #
+   _item.name            "_nef_peak.sequence_code_12"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  20
+   #
+save_
+#
+save__nef_peak.residue_type_12
+   #
+
+   _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 12 of the spectrum."
+   #
+   _item.name            "_nef_peak.residue_type_12"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  ALA
+   #
+save_
+#
+#
+save__nef_peak.atom_name_12
+   #
+
+   _item_description.description  "The atom name for the nuclear assignment associated with dimension 12 of the spectrum."
+   #
+   _item.name            "_nef_peak.atom_name_12"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  HB1
+   #
+save_
+
+#
+save__nef_peak.chain_code_13
+   #
+
+   _item_description.description  "The author provided identifier for a polymer chain or ligand instance for the nuclear assignment associated with dimension 13 of the spectrum."
+   #
+   _item.name            "_nef_peak.chain_code_13"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  B
+   #
+save_
+save__nef_peak.sequence_code_13
+   #
+
+   _item_description.description  "The author provided identifier for the position in polymer sequence for the nuclear assignment associated with dimension 13 of the spectrum."
+   #
+   _item.name            "_nef_peak.sequence_code_13"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  20
+   #
+save_
+#
+save__nef_peak.residue_type_13
+   #
+
+   _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 13 of the spectrum."
+   #
+   _item.name            "_nef_peak.residue_type_13"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  ALA
+   #
+save_
+#
+#
+save__nef_peak.atom_name_13
+   #
+
+   _item_description.description  "The atom name for the nuclear assignment associated with dimension 13 of the spectrum."
+   #
+   _item.name            "_nef_peak.atom_name_13"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  HB1
+   #
+save_
+
+#
+save__nef_peak.chain_code_14
+   #
+
+   _item_description.description  "The author provided identifier for a polymer chain or ligand instance for the nuclear assignment associated with dimension 14 of the spectrum."
+   #
+   _item.name            "_nef_peak.chain_code_14"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  B
+   #
+save_
+save__nef_peak.sequence_code_14
+   #
+
+   _item_description.description  "The author provided identifier for the position in polymer sequence for the nuclear assignment associated with dimension 14 of the spectrum."
+   #
+   _item.name            "_nef_peak.sequence_code_14"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  20
+   #
+save_
+#
+save__nef_peak.residue_type_14
+   #
+
+   _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 14 of the spectrum."
+   #
+   _item.name            "_nef_peak.residue_type_14"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  ALA
+   #
+save_
+#
+#
+save__nef_peak.atom_name_14
+   #
+
+   _item_description.description  "The atom name for the nuclear assignment associated with dimension 14 of the spectrum."
+   #
+   _item.name            "_nef_peak.atom_name_14"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  HB1
+   #
+save_
+
+#
+save__nef_peak.chain_code_15
+   #
+
+   _item_description.description  "The author provided identifier for a polymer chain or ligand instance for the nuclear assignment associated with dimension 15 of the spectrum."
+   #
+   _item.name            "_nef_peak.chain_code_15"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  B
+   #
+save_
+save__nef_peak.sequence_code_15
+   #
+
+   _item_description.description  "The author provided identifier for the position in polymer sequence for the nuclear assignment associated with dimension 15 of the spectrum."
+   #
+   _item.name            "_nef_peak.sequence_code_15"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  20
+   #
+save_
+#
+save__nef_peak.residue_type_15
+   #
+
+   _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 15 of the spectrum."
+   #
+   _item.name            "_nef_peak.residue_type_15"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  ALA
+   #
+save_
+#
+#
+save__nef_peak.atom_name_15
+   #
+
+   _item_description.description  "The atom name for the nuclear assignment associated with dimension 15 of the spectrum."
+   #
+   _item.name            "_nef_peak.atom_name_15"
+   _item.category_id     nef_peak
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  HB1
+   #
+save_
+#
+
+save_nef_peak_restraint_links
+   #
+
+   _category.description     "The data items in the NEF_PEAK_RESTRAINT_LINKS category records the details of the particular list of peak-restraint correspondences used."
+   _category.id              nef_peak_restraint_links
+   _category.mandatory_code  no
+   #
+   _category_group.id  nef_group
+   #   #
+   loop_
+   _category_key.name
+     "_nef_peak_restraint_links.sf_framecode"  
+   #
+   _category_examples.detail  "Example 1"
+   _category_examples.case    
+;   _nef_peak_restraint_links.sf_category   nef_peak_restraint_links
+   _nef_peak_restraint_links.sf_framecode  nef_peak_restraint_links
+;
+
+   #
+save_
+#
+save__nef_peak_restraint_links.sf_category
+   #
+
+   _item_description.description  "An identifier for the saveframe category (type)"
+   #
+   _item.name            "_nef_peak_restraint_links.sf_category"
+   _item.category_id     nef_peak_restraint_links
+   _item.mandatory_code  yes
+   #
+   _item_type.code  idname
+   #
+   _item_examples.case  nef_peak_restraint_links
+   #
+save_
+#
+save__nef_peak_restraint_links.sf_framecode
+   #
+
+   _item_description.description  "An identifier for the saveframe"
+   #
+   _item.name            "_nef_peak_restraint_links.sf_framecode"
+   _item.category_id     nef_peak_restraint_links
+   _item.mandatory_code  yes
+   #
+   _item_type.code nef_framecode
+   #
+   _item_examples.case  nef_peak_restraint_links
+   #
+save_
+
+#
+save_nef_peak_restraint_link
+   #
+
+   _category.description          "The data items in the NEF_PEAK_RESTRAINT_LINK category record the correspondences between peaks and restraints."
+   _category.id                   nef_peak_restraint_link
+   _category.parent_category_id   nef_peak_restraint_links
+   _category.mandatory_code       no
+   #
+   _category_group.id             nef_group
+   #   #
+   loop_
+   _category_key.name
+     "_nef_peak_restraint_link.nmr_spectrum_id"  
+     "_nef_peak_restraint_link.peak_id"  
+     "_nef_peak_restraint_link.restraint_list_id"  
+     "_nef_peak_restraint_link.restraint_id"  
+   #
+   _category_examples.detail  "Example 1"
+   _category_examples.case    
+;   loop_
+      _nef_peak_restraint_link.nmr_spectrum_id
+      _nef_peak_restraint_link.peak_id
+      _nef_peak_restraint_link.restraint_list_id
+      _nef_peak_restraint_link.restraint_id
+      nef_nmr_spectrum_cnoesy1     1   nef_distance_restraint_list_L1     73
+      nef_nmr_spectrum_cnoesy1     1   nef_distance_restraint_list_L1    233
+      nef_nmr_spectrum_cnoesy1   577   nef_distance_restraint_list_L2     12
+      nef_nmr_spectrum_cnoesy1   316   nef_distance_restraint_list_L4   2755
+      nef_nmr_spectrum_cnoesy2   917   nef_distance_restraint_list_L4   2755
+stop_ 
+;
+
+   #
+save_
+#
+save__nef_peak_restraint_link.nmr_spectrum_id
+   #
+
+   _item_description.description  "The identifier for the NMR spectrum in this link relationship."
+   #
+   _item.name            "_nef_peak_restraint_link.nmr_spectrum_id"
+   _item.category_id     nef_peak_restraint_link
+   _item.mandatory_code  yes
+   #
+   _item_type.code nef_framecode
+   #
+   _item_examples.case  nef_nmr_spectrum_cnoesy1
+   #
+   _item_linked.parent_name  "_nef_nmr_spectrum.sf_framecode"
+   _item_linked.child_name   "_nef_peak_restraint_link.nmr_spectrum_id"
+   #
+save_
+#
+save__nef_peak_restraint_link.peak_id
+   #
+
+   _item_description.description  "The identifier for the peak in this link relationship."
+   #
+   _item.name            "_nef_peak_restraint_link.peak_id"
+   _item.category_id     nef_peak_restraint_link
+   _item.mandatory_code  yes
+   #
+   _item_type.code  int
+   #
+   _item_examples.case  1
+   #
+   _item_linked.parent_name  "_nef_peak.peak_id"
+   _item_linked.child_name   "_nef_peak_restraint_link.peak_id"
+   #
+save_
+#
+save__nef_peak_restraint_link.restraint_list_id
+   #
+
+   _item_description.description  "The identifier for the restraint list this link relationship."
+   #
+   _item.name            "_nef_peak_restraint_link.restraint_list_id"
+   _item.category_id     nef_peak_restraint_link
+   _item.mandatory_code  yes
+   #
+   _item_type.code nef_framecode
+   #
+   _item_examples.case  nef_distance_restraint_list_L1
+   #   #
+   loop_
+   _item_linked.parent_name
+   _item_linked.child_name
+     "_nef_dihedral_restraint_list.sf_framecode"  "_nef_peak_restraint_link.restraint_list_id"  
+     "_nef_distance_restraint_list.sf_framecode"  "_nef_peak_restraint_link.restraint_list_id"  
+     "_nef_rdc_restraint_list.sf_framecode"       "_nef_peak_restraint_link.restraint_list_id"  
+   #
+save_
+#
+save__nef_peak_restraint_link.restraint_id
+   #
+
+   _item_description.description  "The identifier for the restraint in this link relationship."
+   #
+   _item.name            "_nef_peak_restraint_link.restraint_id"
+   _item.category_id     nef_peak_restraint_link
+   _item.mandatory_code  yes
+   #
+   _item_type.code  int
+   #
+   _item_examples.case  1
+   #   #
+   loop_
+   _item_linked.parent_name
+   _item_linked.child_name
+     "_nef_dihedral_restraint.restraint_id"  "_nef_peak_restraint_link.restraint_id"  
+     "_nef_distance_restraint.restraint_id"  "_nef_peak_restraint_link.restraint_id"  
+     "_nef_rdc_restraint.restraint_id"       "_nef_peak_restraint_link.restraint_id"  
+   #
+save_


### PR DESCRIPTION
This, to the best of my ability, is the final reflection of the original agreed specification.

Commented_Example.nef has been debugged, the data have been made consistent,
and additional examples of the molecular sequence has been added. The file now does
contain all supported tags.

Overview.md has had some markdown syntax errors fixed and some points clarified.

mmcif_nef.dic is the mmcif specification file already shared with John Westbrook,
with minor additional modifications. Some tags were indicated as mandatory in the commented example (which until the creation of mmcif_nef.dic was the master specification document), and these have now been marked as mandatory in mmcif_nef.dic as well. The relevant tags are:
_nef_nmr_meta_data.format_name, _nef_nmr_meta_data.format_version, _nef_nmr_meta_data.program_name, _nef_nmr_meta_data.program_version, _nef_nmr_meta_data.creation_date,  _nef_nmr_meta_data.uuid
