### PR TITLE
Change proposal - redefine 'break' linking

### DIFF
--- a/specification/Commented_Example.nef
+++ b/specification/Commented_Example.nef
@@ -196,7 +196,7 @@ INSERT PULSE PROGRAM HERE
          D  4    GLY  middle     .
          D  5    PRO  middle     .
          D  6    ASP  cyclic     .
-         E  1    ASN  break      .
+         E  1    ASN  middle      .
          E  2    THR  middle     .
          E  3    ALA  middle     .
          E  4    PRO  middle     cispeptide
@@ -207,9 +207,9 @@ INSERT PULSE PROGRAM HERE
          E  9    GLU  middle     GLU_LL
          E  10   HIS  middle     HIS_LL_DHD1
          E  11   HIS  middle     HIS_LL_DHE2
-         E  12   CYS  middle     CYS_LL
+         E  12   CYS  middle     .
          E  13   LYS  middle     LYS_LL_DHZ3
-         E  14   ARG  break      ARG_LL_DHH12
+         E  14   ARG  middle     ARG_LL_DHH12
          E  14   MOH  nonlinear  .
          F   1   GLY  start      .
          F   2   ILE  middle     .
@@ -245,6 +245,9 @@ INSERT PULSE PROGRAM HERE
 # and 'start' (contains '_LSN3')
 #
 # Chain E shows examples of how to specify the non-default forms supported by the NEF format.
+#
+# The current version does not allow specifying atoms that areremoved to give place for 
+# _nef_covalent_links A change proposal is in place
 
 # Covalent cross-links loop. Optional:
       loop_

--- a/specification/Overview.md
+++ b/specification/Overview.md
@@ -200,7 +200,7 @@ organised by data category (saveframe).
     version 1.3 also. This includes not having duplicate storage slots, so
     that the same information would be found in the same place in both
     versions. Each change should cause an increase in the minor version
-    of the format, so that the minor format number is wexpected to increase
+    of the format, so that the minor format number is expected to increase
     fast over time.
 
     Program-specific tags are not included in this rule, and can be
@@ -279,7 +279,7 @@ organised by data category (saveframe).
     and write sequence descriptions accordingly.
 
     3. Covalent links that are not part of a linear polymer chain are given in
-    the 'covalent_links' loop, which shows which atoms are directly bound.
+    the 'nef_covalent_links' loop, which shows which atoms are directly bound.
     It is not shown which of the atoms from the original template are missing,
     if desired this information must be inferred.
 
@@ -297,10 +297,11 @@ organised by data category (saveframe).
       - 'middle': non-terminal residue in a linear polymer
       - 'single': not part of a linear polymer.
       - 'cyclic': first and last residue of a cyclic linear polymer; the
-        second 'cyclic' residue precedes the first cyclic residue in the
-        sequence
-      - 'break': A residue of linking type 'middle' that lacks a standard
-        linear polymer linkage on either or both sides.
+         second 'cyclic' residue precedes the first cyclic residue in the
+         sequence. Note that the stretch between two 'cyclic' residues may
+         only contain residues of type 'middle'.
+      - 'break' : A residue of linking type 'middle' that does not form an
+        implicit link with the next residue in the sequence.
       - 'nonlinear': A residue that is not of linear polymer type always has
         this linking value.
       - 'dummy': A residue that is not part of the sequence proper,
@@ -309,19 +310,23 @@ organised by data category (saveframe).
         use code UNK.
 
     Sequential linking within a given chain is inferred from the linking column
-    of consecutive residues. Residues of type 'start', 'middle', and 'end' must
-    have the appropriate link to the next/preceding residue in the same chain.
-    Sequences flanked by a 'start'-'end'
-    pair or a 'cyclic'-'cyclic' pair denote a linear or cyclic linear polymer,
-    respectively. The 'break' keyword is used when the first or last residue in
-    a linear polymer stretch is not a chain terminal variant. This might be the
-    case when only part of a sequence is given (discouraged but possible), or
-    when the next link is not a linear polymer link, e.g. for chain caps. Guy
-    Montelione (thanks!) gave an interesting example where the terminal -NH3
-    group was in an amide bond to a glutamate side chain in the same chain;
-    this topology would be given as 'break-middle-middle-middle-
-    ... -middle-end'. Only standard linear polymer links can be inferred from
-    the sequence; other links are given in the 'covalent_links' loop below.
+    of consecutive residues; for simplicity this form of link specification
+    should be used whenever possible in preference to specifying the links
+    explicitly in the 'nef_covalent_links' loop.
+    Residues of type 'start' form the beginning of a
+    linear polymer stretch (preceded by a break), residues of type 'end' form
+    the end of a stretch (followed by a break), and residues of type 'middle'
+    form the continuation of a stretch in both directions - always provided
+    that the neighboring residues allow it. Residues of type 'single',
+    'nonlinear', and 'dummy' do not participate in implicit links and mark a
+    break in the implicit sequence on both sides.
+    Residues of type 'cyclic' mark the beginning and end of a
+    cyclic polymer; they must always appear in pairs and the residues between
+    them must be of type 'middle'. Finally the linking type 'break' is used to
+    indicate a residue with open links in both directions (like type 'middle'),
+    but that does NOT form an implicit link with the following residue in the
+    sequence. This will rarely be necessary, but may be appropriate for
+    sequences with breaks or missing parts (see commented example).
 
     By default residue variants are assumed to be the pH 7 forms,
     specifically fully protonated HIS, LYS, ARG and N-terminus,
@@ -506,8 +511,8 @@ organised by data category (saveframe).
     the measured value to give a set of values that can be compared, as used by
     the program.
 
-    6. The 'distance_dependent' column shows whether the mesurement depends on
-    a variable ineratom distance.
+    6. The 'distance_dependent' column shows whether the measurement depends on
+    a variable interatom distance.
 
   * Regarding Section 8. Optional: **Peak lists(s)**
 

--- a/specification/mmcif_nef.dic
+++ b/specification/mmcif_nef.dic
@@ -827,7 +827,7 @@ save_nef_sequence
     D    4  GLY   middle     .
     D    5  PRO   middle     .
     D    6  ASP   cyclic     .
-    E    1  ASN   break      .
+    E    1  ASN   middle     .
     E    2  THR   middle     .
     E    3  ALA   middle     .
     E    4  PRO   middle     .
@@ -840,8 +840,17 @@ save_nef_sequence
     E   10  HIS	  middle     HIS_LL
     E   11  CYS	  middle     .
     E   12  LYS	  middle     LYS_LL_DHZ3
-    E   13  ARG	  break      ARG_LL_DHH12
+    E   13  ARG	  middle     ARG_LL_DHH12
     E   14  MOH   nonlinear  .
+    F    1  GLY   start      .
+    F    2  ILE   middle     .
+    F    3  SER   middle     .
+    F    4  THR   break      .
+    F   11  ASN   middle     .
+    F   12  SER   end        .
+    G   27  TYR   middle     .
+    G   28  GLY   middle     .
+    G   29  ALA   middle     .
   stop_
   
 # Chain A is a linear dodecapeptide (15-25), disulfide linked to a single
@@ -855,11 +864,17 @@ save_nef_sequence
 # Chain E has an amide bond between the backbone N of ASN 1 and the side chain carboxylate
 # of GLU 6, and a methyl ester cap.
 #
+# Chains F and G represent a chimeric protein, where (part of) chain G has been
+# inserted into chain F while maintaining the original numbering. Each chain is given as a
+# single block of residues, with the 'break' linking to show the chain break, and the 
+# nef_covalent_links loop to show the additional sequential links.
+#
 # residue_variants default to the pH 7 forms, specifically protonated LYS, ARG, and N-terminus
 # and deprotonated ASP, GLU, and C-terminus. 
 # Chain E shows examples of how to specify the non-default forms supported by the NEF format.
 #
-# The current version does not allow specifying atoms that areremoved to give placxe for _nef_covalent_links# A change proposal is in place
+# The current version does not allow specifying atoms that areremoved to give place for 
+# _nef_covalent_links A change proposal is in place
 ;
    #
 save_


### PR DESCRIPTION
Making the system simpler and clearer and reducing the need for 'break' keyword in the sequence linking column.

In the original version, 'break' was defined to be used whenever a residue had both a 'next' and a
'previous' link but either link did not match a regular linear polymer. This was both ambiguous and confusing, and led to overuse of teh 'break' keyword.

In the new proposal, linear polymer links are created implicitly from the order of the residues
whenever the linking values allow it, and 'break' is only needed to mark chain breaks that would otherwise be invisible.  

The behaviour afte the modification is the same as before except for cases including the 'break' keyword, and the net effect is to make 'break' less common.