### PR TITLE
Fixed tag error (origin -> restraint_origin)

### DIFF
--- a/data/CCPN_CASD/2l9r_docr.nef
+++ b/data/CCPN_CASD/2l9r_docr.nef
@@ -879,7 +879,7 @@ data_2l9r_docr
       _nef_distance_restraint_list.sf_category     nef_distance_restraint_list
       _nef_distance_restraint_list.sf_framecode    nef_distance_restraint_list_distance_constraint_list
       _nef_distance_restraint_list.potential_type  unknown
-      _nef_distance_restraint_list.origin          .
+      _nef_distance_restraint_list.restraint_origin          .
 
       loop_
          _nef_distance_restraint.ordinal
@@ -2715,7 +2715,7 @@ data_2l9r_docr
       _nef_distance_restraint_list.sf_category     nef_distance_restraint_list
       _nef_distance_restraint_list.sf_framecode    nef_distance_restraint_list_hBond_constraint_list
       _nef_distance_restraint_list.potential_type  unknown
-      _nef_distance_restraint_list.origin          hbond
+      _nef_distance_restraint_list.restraint_origin          hbond
 
       loop_
          _nef_distance_restraint.ordinal
@@ -2784,7 +2784,7 @@ data_2l9r_docr
       _nef_dihedral_restraint_list.sf_category     nef_dihedral_restraint_list
       _nef_dihedral_restraint_list.sf_framecode    nef_dihedral_restraint_list_dihedral_constraint_list
       _nef_dihedral_restraint_list.potential_type  unknown
-      _nef_dihedral_restraint_list.origin          .
+      _nef_dihedral_restraint_list.restraint_origin          .
 
       loop_
          _nef_dihedral_restraint.ordinal
@@ -2894,7 +2894,7 @@ data_2l9r_docr
       _nef_dihedral_restraint_list.sf_category     nef_dihedral_restraint_list
       _nef_dihedral_restraint_list.sf_framecode    nef_dihedral_restraint_list_dihedral_constraint_list_1
       _nef_dihedral_restraint_list.potential_type  unknown
-      _nef_dihedral_restraint_list.origin          .
+      _nef_dihedral_restraint_list.restraint_origin          .
 
       loop_
          _nef_dihedral_restraint.ordinal
@@ -3004,7 +3004,7 @@ data_2l9r_docr
       _nef_rdc_restraint_list.sf_category           nef_rdc_restraint_list
       _nef_rdc_restraint_list.sf_framecode          nef_rdc_restraint_list_peg_gel-1
       _nef_rdc_restraint_list.potential_type        unknown
-      _nef_rdc_restraint_list.origin                .
+      _nef_rdc_restraint_list.restraint_origin      .
       _nef_rdc_restraint_list.tensor_magnitude      13.28
       _nef_rdc_restraint_list.tensor_rhombicity     0.252
       _nef_rdc_restraint_list.tensor_chain_code     .
@@ -3078,7 +3078,7 @@ data_2l9r_docr
       _nef_rdc_restraint_list.sf_category           nef_rdc_restraint_list
       _nef_rdc_restraint_list.sf_framecode          nef_rdc_restraint_list_peg_gel-2
       _nef_rdc_restraint_list.potential_type        unknown
-      _nef_rdc_restraint_list.origin                .
+      _nef_rdc_restraint_list.restraint_origin      .
       _nef_rdc_restraint_list.tensor_magnitude      -1.255
       _nef_rdc_restraint_list.tensor_rhombicity     0.336
       _nef_rdc_restraint_list.tensor_chain_code     .

--- a/data/CCPN_CASD/2la6_docr.nef
+++ b/data/CCPN_CASD/2la6_docr.nef
@@ -1168,7 +1168,7 @@ data_2la6_docr
       _nef_distance_restraint_list.sf_category     nef_distance_restraint_list
       _nef_distance_restraint_list.sf_framecode    nef_distance_restraint_list_distance_constraint_list
       _nef_distance_restraint_list.potential_type  unknown
-      _nef_distance_restraint_list.origin          .
+      _nef_distance_restraint_list.restraint_origin          .
 
       loop_
          _nef_distance_restraint.ordinal
@@ -4375,7 +4375,7 @@ data_2la6_docr
       _nef_distance_restraint_list.sf_category     nef_distance_restraint_list
       _nef_distance_restraint_list.sf_framecode    nef_distance_restraint_list_hBond_constraint_list
       _nef_distance_restraint_list.potential_type  unknown
-      _nef_distance_restraint_list.origin          hbond
+      _nef_distance_restraint_list.restraint_origin          hbond
 
       loop_
          _nef_distance_restraint.ordinal
@@ -4436,7 +4436,7 @@ data_2la6_docr
       _nef_dihedral_restraint_list.sf_category     nef_dihedral_restraint_list
       _nef_dihedral_restraint_list.sf_framecode    nef_dihedral_restraint_list_dihedral_constraint_list
       _nef_dihedral_restraint_list.potential_type  unknown
-      _nef_dihedral_restraint_list.origin          .
+      _nef_dihedral_restraint_list.restraint_origin          .
 
       loop_
          _nef_dihedral_restraint.ordinal
@@ -4556,7 +4556,7 @@ data_2la6_docr
       _nef_rdc_restraint_list.sf_category           nef_rdc_restraint_list
       _nef_rdc_restraint_list.sf_framecode          nef_rdc_restraint_list_peg_gel-1
       _nef_rdc_restraint_list.potential_type        unknown
-      _nef_rdc_restraint_list.origin                .
+      _nef_rdc_restraint_list.restraint_origin      .
       _nef_rdc_restraint_list.tensor_magnitude      9
       _nef_rdc_restraint_list.tensor_rhombicity     0.415
       _nef_rdc_restraint_list.tensor_chain_code     .
@@ -4655,7 +4655,7 @@ data_2la6_docr
       _nef_rdc_restraint_list.sf_category           nef_rdc_restraint_list
       _nef_rdc_restraint_list.sf_framecode          nef_rdc_restraint_list_peg_gel-2
       _nef_rdc_restraint_list.potential_type        unknown
-      _nef_rdc_restraint_list.origin                .
+      _nef_rdc_restraint_list.restraint_origin      .
       _nef_rdc_restraint_list.tensor_magnitude      -8.747
       _nef_rdc_restraint_list.tensor_rhombicity     0.448
       _nef_rdc_restraint_list.tensor_chain_code     .

--- a/data/CCPN_CASD/2lah_docr.nef
+++ b/data/CCPN_CASD/2lah_docr.nef
@@ -2028,7 +2028,7 @@ data_2lah_docr
       _nef_distance_restraint_list.sf_category     nef_distance_restraint_list
       _nef_distance_restraint_list.sf_framecode    nef_distance_restraint_list_distance_constraint_list
       _nef_distance_restraint_list.potential_type  unknown
-      _nef_distance_restraint_list.origin          .
+      _nef_distance_restraint_list.restraint_origin          .
 
       loop_
          _nef_distance_restraint.ordinal
@@ -7496,7 +7496,7 @@ data_2lah_docr
       _nef_distance_restraint_list.sf_category     nef_distance_restraint_list
       _nef_distance_restraint_list.sf_framecode    nef_distance_restraint_list_hBond_constraint_list
       _nef_distance_restraint_list.potential_type  unknown
-      _nef_distance_restraint_list.origin          hbond
+      _nef_distance_restraint_list.restraint_origin          hbond
 
       loop_
          _nef_distance_restraint.ordinal
@@ -7609,7 +7609,7 @@ data_2lah_docr
       _nef_dihedral_restraint_list.sf_category     nef_dihedral_restraint_list
       _nef_dihedral_restraint_list.sf_framecode    nef_dihedral_restraint_list_dihedral_constraint_list
       _nef_dihedral_restraint_list.potential_type  unknown
-      _nef_dihedral_restraint_list.origin          .
+      _nef_dihedral_restraint_list.restraint_origin          .
 
       loop_
          _nef_dihedral_restraint.ordinal
@@ -7869,7 +7869,7 @@ data_2lah_docr
       _nef_rdc_restraint_list.sf_category           nef_rdc_restraint_list
       _nef_rdc_restraint_list.sf_framecode          nef_rdc_restraint_list_cya-1
       _nef_rdc_restraint_list.potential_type        unknown
-      _nef_rdc_restraint_list.origin                .
+      _nef_rdc_restraint_list.restraint_origin      .
       _nef_rdc_restraint_list.tensor_magnitude      10.834
       _nef_rdc_restraint_list.tensor_rhombicity     0.487
       _nef_rdc_restraint_list.tensor_chain_code     .

--- a/data/CCPN_CASD/2lci_docr.nef
+++ b/data/CCPN_CASD/2lci_docr.nef
@@ -1780,7 +1780,7 @@ data_2lci_docr
       _nef_distance_restraint_list.sf_category     nef_distance_restraint_list
       _nef_distance_restraint_list.sf_framecode    nef_distance_restraint_list_distance_constraint_list
       _nef_distance_restraint_list.potential_type  unknown
-      _nef_distance_restraint_list.origin          .
+      _nef_distance_restraint_list.restraint_origin          .
 
       loop_
          _nef_distance_restraint.ordinal
@@ -6222,7 +6222,7 @@ data_2lci_docr
       _nef_distance_restraint_list.sf_category     nef_distance_restraint_list
       _nef_distance_restraint_list.sf_framecode    nef_distance_restraint_list_hBond_constraint_list
       _nef_distance_restraint_list.potential_type  unknown
-      _nef_distance_restraint_list.origin          hbond
+      _nef_distance_restraint_list.restraint_origin          hbond
 
       loop_
          _nef_distance_restraint.ordinal
@@ -6311,7 +6311,7 @@ data_2lci_docr
       _nef_dihedral_restraint_list.sf_category     nef_dihedral_restraint_list
       _nef_dihedral_restraint_list.sf_framecode    nef_dihedral_restraint_list_dihedral_constraint_list
       _nef_dihedral_restraint_list.potential_type  unknown
-      _nef_dihedral_restraint_list.origin          .
+      _nef_dihedral_restraint_list.restraint_origin          .
 
       loop_
          _nef_dihedral_restraint.ordinal
@@ -6547,7 +6547,7 @@ data_2lci_docr
       _nef_rdc_restraint_list.sf_category           nef_rdc_restraint_list
       _nef_rdc_restraint_list.sf_framecode          nef_rdc_restraint_list_cya-1
       _nef_rdc_restraint_list.potential_type        unknown
-      _nef_rdc_restraint_list.origin                .
+      _nef_rdc_restraint_list.restraint_origin      .
       _nef_rdc_restraint_list.tensor_magnitude      6.353
       _nef_rdc_restraint_list.tensor_rhombicity     0.601
       _nef_rdc_restraint_list.tensor_chain_code     .
@@ -6663,7 +6663,7 @@ data_2lci_docr
       _nef_rdc_restraint_list.sf_category           nef_rdc_restraint_list
       _nef_rdc_restraint_list.sf_framecode          nef_rdc_restraint_list_cya-2
       _nef_rdc_restraint_list.potential_type        unknown
-      _nef_rdc_restraint_list.origin                .
+      _nef_rdc_restraint_list.restraint_origin      .
       _nef_rdc_restraint_list.tensor_magnitude      -6.818
       _nef_rdc_restraint_list.tensor_rhombicity     0.282
       _nef_rdc_restraint_list.tensor_chain_code     .

--- a/data/CCPN_CASD/2ln3_docr.nef
+++ b/data/CCPN_CASD/2ln3_docr.nef
@@ -1073,7 +1073,7 @@ data_2ln3_docr
       _nef_distance_restraint_list.sf_category     nef_distance_restraint_list
       _nef_distance_restraint_list.sf_framecode    nef_distance_restraint_list_distance_constraint_list
       _nef_distance_restraint_list.potential_type  unknown
-      _nef_distance_restraint_list.origin          .
+      _nef_distance_restraint_list.restraint_origin          .
 
       loop_
          _nef_distance_restraint.ordinal
@@ -5173,7 +5173,7 @@ data_2ln3_docr
       _nef_distance_restraint_list.sf_category     nef_distance_restraint_list
       _nef_distance_restraint_list.sf_framecode    nef_distance_restraint_list_hBond_constraint_list
       _nef_distance_restraint_list.potential_type  unknown
-      _nef_distance_restraint_list.origin          hbond
+      _nef_distance_restraint_list.restraint_origin          hbond
 
       loop_
          _nef_distance_restraint.ordinal
@@ -5274,7 +5274,7 @@ data_2ln3_docr
       _nef_dihedral_restraint_list.sf_category     nef_dihedral_restraint_list
       _nef_dihedral_restraint_list.sf_framecode    nef_dihedral_restraint_list_dihedral_constraint_list
       _nef_dihedral_restraint_list.potential_type  unknown
-      _nef_dihedral_restraint_list.origin          .
+      _nef_dihedral_restraint_list.restraint_origin          .
 
       loop_
          _nef_dihedral_restraint.ordinal
@@ -5422,7 +5422,7 @@ data_2ln3_docr
       _nef_rdc_restraint_list.sf_category           nef_rdc_restraint_list
       _nef_rdc_restraint_list.sf_framecode          nef_rdc_restraint_list_cya-1
       _nef_rdc_restraint_list.potential_type        unknown
-      _nef_rdc_restraint_list.origin                .
+      _nef_rdc_restraint_list.restraint_origin      .
       _nef_rdc_restraint_list.tensor_magnitude      11
       _nef_rdc_restraint_list.tensor_rhombicity     0.067
       _nef_rdc_restraint_list.tensor_chain_code     .
@@ -5513,7 +5513,7 @@ data_2ln3_docr
       _nef_rdc_restraint_list.sf_category           nef_rdc_restraint_list
       _nef_rdc_restraint_list.sf_framecode          nef_rdc_restraint_list_cya-2
       _nef_rdc_restraint_list.potential_type        unknown
-      _nef_rdc_restraint_list.origin                .
+      _nef_rdc_restraint_list.restraint_origin      .
       _nef_rdc_restraint_list.tensor_magnitude      -14.651
       _nef_rdc_restraint_list.tensor_rhombicity     0.479
       _nef_rdc_restraint_list.tensor_chain_code     .

--- a/data/CCPN_CASD/2ltl_docr.nef
+++ b/data/CCPN_CASD/2ltl_docr.nef
@@ -1354,7 +1354,7 @@ data_2ltl_docr
       _nef_distance_restraint_list.sf_category     nef_distance_restraint_list
       _nef_distance_restraint_list.sf_framecode    nef_distance_restraint_list_distance_constraint_list
       _nef_distance_restraint_list.potential_type  unknown
-      _nef_distance_restraint_list.origin          .
+      _nef_distance_restraint_list.restraint_origin          .
 
       loop_
          _nef_distance_restraint.ordinal
@@ -4697,7 +4697,7 @@ data_2ltl_docr
       _nef_distance_restraint_list.sf_category     nef_distance_restraint_list
       _nef_distance_restraint_list.sf_framecode    nef_distance_restraint_list_hBond_constraint_list
       _nef_distance_restraint_list.potential_type  unknown
-      _nef_distance_restraint_list.origin          hbond
+      _nef_distance_restraint_list.restraint_origin          hbond
 
       loop_
          _nef_distance_restraint.ordinal
@@ -4768,7 +4768,7 @@ data_2ltl_docr
       _nef_dihedral_restraint_list.sf_category     nef_dihedral_restraint_list
       _nef_dihedral_restraint_list.sf_framecode    nef_dihedral_restraint_list_dihedral_constraint_list
       _nef_dihedral_restraint_list.potential_type  unknown
-      _nef_dihedral_restraint_list.origin          .
+      _nef_dihedral_restraint_list.restraint_origin          .
 
       loop_
          _nef_dihedral_restraint.ordinal
@@ -4930,7 +4930,7 @@ data_2ltl_docr
       _nef_rdc_restraint_list.sf_category           nef_rdc_restraint_list
       _nef_rdc_restraint_list.sf_framecode          nef_rdc_restraint_list_cya-1
       _nef_rdc_restraint_list.potential_type        unknown
-      _nef_rdc_restraint_list.origin                .
+      _nef_rdc_restraint_list.restraint_origin      .
       _nef_rdc_restraint_list.tensor_magnitude      -7.307
       _nef_rdc_restraint_list.tensor_rhombicity     0.161
       _nef_rdc_restraint_list.tensor_chain_code     .
@@ -5021,7 +5021,7 @@ data_2ltl_docr
       _nef_rdc_restraint_list.sf_category           nef_rdc_restraint_list
       _nef_rdc_restraint_list.sf_framecode          nef_rdc_restraint_list_cya-2
       _nef_rdc_restraint_list.potential_type        unknown
-      _nef_rdc_restraint_list.origin                .
+      _nef_rdc_restraint_list.restraint_origin      .
       _nef_rdc_restraint_list.tensor_magnitude      11.923
       _nef_rdc_restraint_list.tensor_rhombicity     0.317
       _nef_rdc_restraint_list.tensor_chain_code     .

--- a/data/CCPN_CASD/2ltm_docr.nef
+++ b/data/CCPN_CASD/2ltm_docr.nef
@@ -1304,7 +1304,7 @@ data_2ltm_docr
       _nef_distance_restraint_list.sf_category     nef_distance_restraint_list
       _nef_distance_restraint_list.sf_framecode    nef_distance_restraint_list_distance_constraint_list
       _nef_distance_restraint_list.potential_type  unknown
-      _nef_distance_restraint_list.origin          .
+      _nef_distance_restraint_list.restraint_origin          .
 
       loop_
          _nef_distance_restraint.ordinal
@@ -5247,7 +5247,7 @@ data_2ltm_docr
       _nef_distance_restraint_list.sf_category     nef_distance_restraint_list
       _nef_distance_restraint_list.sf_framecode    nef_distance_restraint_list_hBond_constraint_list
       _nef_distance_restraint_list.potential_type  unknown
-      _nef_distance_restraint_list.origin          hbond
+      _nef_distance_restraint_list.restraint_origin          hbond
 
       loop_
          _nef_distance_restraint.ordinal
@@ -5328,7 +5328,7 @@ data_2ltm_docr
       _nef_dihedral_restraint_list.sf_category     nef_dihedral_restraint_list
       _nef_dihedral_restraint_list.sf_framecode    nef_dihedral_restraint_list_dihedral_constraint_list
       _nef_dihedral_restraint_list.potential_type  unknown
-      _nef_dihedral_restraint_list.origin          .
+      _nef_dihedral_restraint_list.restraint_origin          .
 
       loop_
          _nef_dihedral_restraint.ordinal
@@ -5480,7 +5480,7 @@ data_2ltm_docr
       _nef_rdc_restraint_list.sf_category           nef_rdc_restraint_list
       _nef_rdc_restraint_list.sf_framecode          nef_rdc_restraint_list_cya-1
       _nef_rdc_restraint_list.potential_type        unknown
-      _nef_rdc_restraint_list.origin                .
+      _nef_rdc_restraint_list.restraint_origin      .
       _nef_rdc_restraint_list.tensor_magnitude      14.479
       _nef_rdc_restraint_list.tensor_rhombicity     0.087
       _nef_rdc_restraint_list.tensor_chain_code     .
@@ -5578,7 +5578,7 @@ data_2ltm_docr
       _nef_rdc_restraint_list.sf_category           nef_rdc_restraint_list
       _nef_rdc_restraint_list.sf_framecode          nef_rdc_restraint_list_cya-2
       _nef_rdc_restraint_list.potential_type        unknown
-      _nef_rdc_restraint_list.origin                .
+      _nef_rdc_restraint_list.restraint_origin      .
       _nef_rdc_restraint_list.tensor_magnitude      14.764
       _nef_rdc_restraint_list.tensor_rhombicity     0.413
       _nef_rdc_restraint_list.tensor_chain_code     .

--- a/data/CCPN_CASD/2m2e_docr.nef
+++ b/data/CCPN_CASD/2m2e_docr.nef
@@ -1006,7 +1006,7 @@ data_2m2e_docr
       _nef_distance_restraint_list.sf_category     nef_distance_restraint_list
       _nef_distance_restraint_list.sf_framecode    nef_distance_restraint_list_distance_constraint_list
       _nef_distance_restraint_list.potential_type  unknown
-      _nef_distance_restraint_list.origin          .
+      _nef_distance_restraint_list.restraint_origin          .
 
       loop_
          _nef_distance_restraint.ordinal
@@ -2903,7 +2903,7 @@ data_2m2e_docr
       _nef_dihedral_restraint_list.sf_category     nef_dihedral_restraint_list
       _nef_dihedral_restraint_list.sf_framecode    nef_dihedral_restraint_list_dihedral_constraint_list
       _nef_dihedral_restraint_list.potential_type  unknown
-      _nef_dihedral_restraint_list.origin          .
+      _nef_dihedral_restraint_list.restraint_origin          .
 
       loop_
          _nef_dihedral_restraint.ordinal

--- a/data/CCPN_CASD/2m5o_docr.nef
+++ b/data/CCPN_CASD/2m5o_docr.nef
@@ -1130,7 +1130,7 @@ data_2m5o_docr
       _nef_distance_restraint_list.sf_category     nef_distance_restraint_list
       _nef_distance_restraint_list.sf_framecode    nef_distance_restraint_list_distance_constraint_list
       _nef_distance_restraint_list.potential_type  unknown
-      _nef_distance_restraint_list.origin          .
+      _nef_distance_restraint_list.restraint_origin          .
 
       loop_
          _nef_distance_restraint.ordinal
@@ -5184,7 +5184,7 @@ data_2m5o_docr
       _nef_dihedral_restraint_list.sf_category     nef_dihedral_restraint_list
       _nef_dihedral_restraint_list.sf_framecode    nef_dihedral_restraint_list_dihedral_constraint_list
       _nef_dihedral_restraint_list.potential_type  unknown
-      _nef_dihedral_restraint_list.origin          .
+      _nef_dihedral_restraint_list.restraint_origin          .
 
       loop_
          _nef_dihedral_restraint.ordinal
@@ -5344,7 +5344,7 @@ data_2m5o_docr
       _nef_rdc_restraint_list.sf_category           nef_rdc_restraint_list
       _nef_rdc_restraint_list.sf_framecode          nef_rdc_restraint_list_cya-1
       _nef_rdc_restraint_list.potential_type        unknown
-      _nef_rdc_restraint_list.origin                .
+      _nef_rdc_restraint_list.restraint_origin                .
       _nef_rdc_restraint_list.tensor_magnitude      4.9
       _nef_rdc_restraint_list.tensor_rhombicity     0.592
       _nef_rdc_restraint_list.tensor_chain_code     .
@@ -5428,7 +5428,7 @@ data_2m5o_docr
       _nef_rdc_restraint_list.sf_category           nef_rdc_restraint_list
       _nef_rdc_restraint_list.sf_framecode          nef_rdc_restraint_list_cya-2
       _nef_rdc_restraint_list.potential_type        unknown
-      _nef_rdc_restraint_list.origin                .
+      _nef_rdc_restraint_list.restraint_origin      .
       _nef_rdc_restraint_list.tensor_magnitude      -5.102
       _nef_rdc_restraint_list.tensor_rhombicity     0.319
       _nef_rdc_restraint_list.tensor_chain_code     .

--- a/data/CCPN_CASD/README.txt
+++ b/data/CCPN_CASD/README.txt
@@ -11,13 +11,17 @@ OR135 	2LN3 	09/02/2012 18145
 OR36 	2LCI 	24/06/2011 17613
 HR5460A 2LAH 	09/05/2011 17524
 HR6430A	2LA6 	29/04/2011 17508
-HR6470A 2L9R 	19/04/2011 17484
+HR6470A 2L9R 	19/04/2011 17484  1)
 
 CASD test data can be downloaded from https://www.wenmr.eu/wenmr/casd-nmr-data-sets
 
 BMRB entries can be downloaded from http://www.bmrb.wisc.edu/search/
 
 DOCR projects can be downloaded from http://restraintsgrid.bmrb.wisc.edu/NRG/MRGridServlet
+
+1) This project contains two identical dihedral_restraint_lists. Since the DOCR
+entry contains the same error, I have left the files unchanged (and consistent with
+the starting point).
 
 
 NEF file generation:


### PR DESCRIPTION
Fixed incorrect tag in test files:
nef_distance_restraint_list.origin -> nef_distance_restraint_list.restraint_origin

Also added comment in README to warn of duplicate dihedral restraint lins in 2l9r_docr.nef (as it arises from an error in the source DOCR project, I have left it in for consistency).

Thanks to Roberto Tejero for spotting both. 