### PR TITLE
Add program_raw_data saveframe AND change atom names (HBX  to HBx, ...)

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,13 @@
 Change log
 ==========
 
+**Proposal multiple changes**
+
+* Add program_specific_raw_data saveframe
+* Change nonsereospecific wildcards from X/Y (upper case) to x/y (lower case)
+* Tighten allowed wildcards
+* Improve consistency of COmmented_Example
+
 **Proposal remove_chemical_shift_units**
 
 * Remove  _nef_chemical_shift_list.atom_chemical_shift_units tag

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,10 @@
 Change log
 ==========
 
+**Proposal remove_chemical_shift_units**
+
+* Remove  _nef_chemical_shift_list.atom_chemical_shift_units tag
+
 **Proposal ordinal_to_index_id**
 
 * change 'ordinal' to 'index_id' 

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,15 @@
 Change log
 ==========
 
+**Proposal ordinal_to_index_id**
+
+* change 'ordinal' to 'index_id' 
+(preserving _nef_run_history.run_ordinal, which *does* signify an ordering)
+
+**Proposal residue_type_to_name**
+
+* change 'residue_type' to 'residue_name' in all occurrences and tags
+
 **Version 0.2**
 
 * Version 0.2 (unfortunately named) is the final, cleaned-up version before

--- a/specification/Commented_Example.nef
+++ b/specification/Commented_Example.nef
@@ -404,7 +404,7 @@ save_nef_distance_restraint_list_L1
 
       loop_
          # Mandatory parameters, except for restraint_combination_id
-         _nef_distance_restraint.ordinal
+         _nef_distance_restraint.index_id
          _nef_distance_restraint.restraint_id
          _nef_distance_restraint.restraint_combination_id
          _nef_distance_restraint.chain_code_1
@@ -427,7 +427,7 @@ save_nef_distance_restraint_list_L1
          _nef_distance_restraint.upper_limit
          _nef_distance_restraint.upper_linear_limit
       
-         # key: ordinal
+         # key: index_id
 
          1  1  .  A  17  VAL  H    A  21  ALA  HB%   1  3.7  0.4  2    2.5  4.2  4.7
          2  1  .  A  17  VAL  H    A  22  THR  HG2%  1  3.7  0.4  2    2.5  4.2  4.7
@@ -438,7 +438,7 @@ save_nef_distance_restraint_list_L1
          7  8  .  A  24  ASP  HBY  E   7  SER  HB2   1  4.4  0.4  3.6  4.1  5.2  5.7
       stop_
 
-      # The first column (ordinal) is a consecutive line number that does not persist  
+      # The first column (index_id) is a consecutive line number that does not persist  
       # when data are re-exported
       # The second column gives the restraint ID.
       # Lines with the same restraint_id are combined into a single restraint
@@ -468,7 +468,7 @@ save_nef_distance_restraint_list_hbond1
 
       loop_
          # Mandatory parameters, except for restraint_combination_id
-         _nef_distance_restraint.ordinal
+         _nef_distance_restraint.index_id
          _nef_distance_restraint.restraint_id
          _nef_distance_restraint.restraint_combination_id
          _nef_distance_restraint.chain_code_1
@@ -491,7 +491,7 @@ save_nef_distance_restraint_list_hbond1
          _nef_distance_restraint.upper_limit
          _nef_distance_restraint.upper_linear_limit
       
-         # key: ordinal
+         # key: index_id
 
          1  1  .  A  15  VAL  H    A  24B  THR  O     1  1.8    .  .  1.4    2.7  .
          2  2  .  A  15  VAL  N    A  24B  THR  O     1  2.8    .  .  2.4    3.7  .
@@ -503,7 +503,7 @@ save_nef_distance_restraint_list_hbond1
          8  4  3  A  17  VAL  N    A  24   ASP  O     1  2.8    .  .  2.4    3.7  .
       stop_
 
-      # The first column (ordinal) is a consecutive line number that does not persist  
+      # The first column (index_id) is a consecutive line number that does not persist  
       # when data are re-exported
       # The second column gives the restraint ID.
       # Lines with the same restraint_id are combined into a single restraint
@@ -540,7 +540,7 @@ save_nef_distance_restraint_list_hbond1
 
       loop_
          # Mandatory parameters, except for restraint_combination_id
-         _nef_dihedral_restraint.ordinal
+         _nef_dihedral_restraint.index_id
          _nef_dihedral_restraint.restraint_id
          _nef_dihedral_restraint.restraint_combination_id
          _nef_dihedral_restraint.chain_code_1
@@ -572,7 +572,7 @@ save_nef_distance_restraint_list_hbond1
          _nef_dihedral_restraint.upper_linear_limit
          _nef_dihedral_restraint.name
       
-         # key: ordinal
+         # key: index_id
          
          1   1  .  A  21  ALA  N   A  21  ALA  CA  A  21  ALA  C   A  22   THR  N    1  -50  5  .  -60  -40  .  PSI
          2   1  .  A  21  ALA  N   A  21  ALA  CA  A  21  ALA  C   A  22   THR  N    1  105  5  .  90   120  .  PSI
@@ -638,7 +638,7 @@ save_nef_distance_restraint_list_hbond1
 
       loop_
          # Mandatory parameters, except for restraint_combination_id
-         _nef_rdc_restraint.ordinal
+         _nef_rdc_restraint.index_id
          _nef_rdc_restraint.restraint_id
          _nef_rdc_restraint.restraint_combination_id
          _nef_rdc_restraint.chain_code_1
@@ -665,7 +665,7 @@ save_nef_distance_restraint_list_hbond1
          _nef_rdc_restraint.scale
          _nef_rdc_restraint.distance_dependent
 
-         # key: ordinal
+         # key: index_id
 
          1  1  .  A  21  ALA  H  A  21  ALA  N  1  -5.2  0.33  .  .  .  .  1  false
          2  2  .  A  22  THR  H  A  22  THR  N  1  3.1   0.4   .  .  .  .  1  false
@@ -773,7 +773,7 @@ save_nef_distance_restraint_list_hbond1
       # Dimensions are given in the order of the _nef_Spectrum.dimension_id defined above.
 
       loop_
-         _nef_peak.ordinal
+         _nef_peak.index_id
          _nef_peak.peak_id
          _nef_peak.volume
          _nef_peak.volume_uncertainty
@@ -798,7 +798,7 @@ save_nef_distance_restraint_list_hbond1
          _nef_peak.residue_name_3
          _nef_peak.atom_name_3
 
-         # key: ordinal
+         # key: index_id
 
          1   1  73000000  5100000   33000000  1100000   3.2  0.05  119.5  0.5  8.3  0.03  A  14  TRP  HB3  A  18    PHE  N    A  18    PHE  H  
          2   1  73000000  5100000   33000000  1100000   3.2  0.05  119.5  0.5  8.3  0.03  A  19  LEU  HBY  A  24B   GLN  N    A  24B   GLN  H  
@@ -882,7 +882,7 @@ save_nef_distance_restraint_list_hbond1
       # and ignore spectra of too high dimensionality
 
       loop_
-         _nef_peak.ordinal
+         _nef_peak.index_id
          _nef_peak.peak_id
          _nef_peak.volume
          _nef_peak.volume_uncertainty
@@ -979,7 +979,7 @@ save_nef_distance_restraint_list_hbond1
          _nef_peak.residue_name_15
          _nef_peak.atom_name_15
       
-         # key: ordinal
+         # key: index_id
 
          1  1  73000000  5100000  33000000  1100000  7.2  0.05  119.5  0.4  28.3  0.3  172.2  0.5  58.5  0.4  32.3  0.4  22.2  0.5  58.5  0.4  32.3  0.4  22.2  0.5  58.5  0.4  32.3  0.4  22.2  0.5  58.5  0.4  32.3  0.4  A  19  LEU  HN  A  19  LEU  N  A  24C   GLN  C  A  19  LEU  CA  A  19  LEU  CB  A  19  LEU  CG  A  19  LEU  CD1  A  19  LEU  CD2  A  19  LEU  CG  A  19  LEU  CA  A  19  LEU  CB  A  19  LEU  CG  A  24C   GLN  CA  A  24C   GLN  CB  A  24C   GLN  CG
       stop_

--- a/specification/Commented_Example.nef
+++ b/specification/Commented_Example.nef
@@ -159,7 +159,7 @@ INSERT PULSE PROGRAM HERE
 	 # mandatory parameters
          _nef_sequence.chain_code
          _nef_sequence.sequence_code
-         _nef_sequence.residue_type
+         _nef_sequence.residue_name
          
 	 # optional parameters
          _nef_sequence.linking
@@ -267,11 +267,11 @@ INSERT PULSE PROGRAM HERE
          # mandatory parameters
          _nef_covalent_links.chain_code_1
          _nef_covalent_links.sequence_code_1
-         _nef_covalent_links.residue_type_1
+         _nef_covalent_links.residue_name_1
          _nef_covalent_links.atom_name_1
          _nef_covalent_links.chain_code_2
          _nef_covalent_links.sequence_code_2
-         _nef_covalent_links.residue_type_2
+         _nef_covalent_links.residue_name_2
          _nef_covalent_links.atom_name_2
 
          # key: chain_code_1, sequence_code_1, atom_name_1, chain_code_2, sequence_code_2, atom_name_2
@@ -307,7 +307,7 @@ INSERT PULSE PROGRAM HERE
       loop_
          _nef_chemical_shift.chain_code
          _nef_chemical_shift.sequence_code
-         _nef_chemical_shift.residue_type
+         _nef_chemical_shift.residue_name
          _nef_chemical_shift.atom_name
          _nef_chemical_shift.value
          _nef_chemical_shift.value_uncertainty
@@ -409,11 +409,11 @@ save_nef_distance_restraint_list_L1
          _nef_distance_restraint.restraint_combination_id
          _nef_distance_restraint.chain_code_1
          _nef_distance_restraint.sequence_code_1
-         _nef_distance_restraint.residue_type_1
+         _nef_distance_restraint.residue_name_1
          _nef_distance_restraint.atom_name_1
          _nef_distance_restraint.chain_code_2
          _nef_distance_restraint.sequence_code_2
-         _nef_distance_restraint.residue_type_2
+         _nef_distance_restraint.residue_name_2
          _nef_distance_restraint.atom_name_2
          _nef_distance_restraint.weight
 
@@ -473,11 +473,11 @@ save_nef_distance_restraint_list_hbond1
          _nef_distance_restraint.restraint_combination_id
          _nef_distance_restraint.chain_code_1
          _nef_distance_restraint.sequence_code_1
-         _nef_distance_restraint.residue_type_1
+         _nef_distance_restraint.residue_name_1
          _nef_distance_restraint.atom_name_1
          _nef_distance_restraint.chain_code_2
          _nef_distance_restraint.sequence_code_2
-         _nef_distance_restraint.residue_type_2
+         _nef_distance_restraint.residue_name_2
          _nef_distance_restraint.atom_name_2
          _nef_distance_restraint.weight
 
@@ -545,19 +545,19 @@ save_nef_distance_restraint_list_hbond1
          _nef_dihedral_restraint.restraint_combination_id
          _nef_dihedral_restraint.chain_code_1
          _nef_dihedral_restraint.sequence_code_1
-         _nef_dihedral_restraint.residue_type_1
+         _nef_dihedral_restraint.residue_name_1
          _nef_dihedral_restraint.atom_name_1
          _nef_dihedral_restraint.chain_code_2
          _nef_dihedral_restraint.sequence_code_2
-         _nef_dihedral_restraint.residue_type_2
+         _nef_dihedral_restraint.residue_name_2
          _nef_dihedral_restraint.atom_name_2
          _nef_dihedral_restraint.chain_code_3
          _nef_dihedral_restraint.sequence_code_3
-         _nef_dihedral_restraint.residue_type_3
+         _nef_dihedral_restraint.residue_name_3
          _nef_dihedral_restraint.atom_name_3
          _nef_dihedral_restraint.chain_code_4
          _nef_dihedral_restraint.sequence_code_4
-         _nef_dihedral_restraint.residue_type_4
+         _nef_dihedral_restraint.residue_name_4
          _nef_dihedral_restraint.atom_name_4
          _nef_dihedral_restraint.weight
 
@@ -634,7 +634,7 @@ save_nef_distance_restraint_list_hbond1
       _nef_rdc_restraint_list.tensor_rhombicity     0.067
       _nef_rdc_restraint_list.tensor_chain_code     C
       _nef_rdc_restraint_list.tensor_sequence_code  900
-      _nef_rdc_restraint_list.tensor_residue_type   TNSR
+      _nef_rdc_restraint_list.tensor_residue_name   TNSR
 
       loop_
          # Mandatory parameters, except for restraint_combination_id
@@ -643,11 +643,11 @@ save_nef_distance_restraint_list_hbond1
          _nef_rdc_restraint.restraint_combination_id
          _nef_rdc_restraint.chain_code_1
          _nef_rdc_restraint.sequence_code_1
-         _nef_rdc_restraint.residue_type_1
+         _nef_rdc_restraint.residue_name_1
          _nef_rdc_restraint.atom_name_1
          _nef_rdc_restraint.chain_code_2
          _nef_rdc_restraint.sequence_code_2
-         _nef_rdc_restraint.residue_type_2
+         _nef_rdc_restraint.residue_name_2
          _nef_rdc_restraint.atom_name_2
          _nef_rdc_restraint.weight
 
@@ -787,15 +787,15 @@ save_nef_distance_restraint_list_hbond1
          _nef_peak.position_uncertainty_3
          _nef_peak.chain_code_1
          _nef_peak.sequence_code_1
-         _nef_peak.residue_type_1
+         _nef_peak.residue_name_1
          _nef_peak.atom_name_1
          _nef_peak.chain_code_2
          _nef_peak.sequence_code_2
-         _nef_peak.residue_type_2
+         _nef_peak.residue_name_2
          _nef_peak.atom_name_2
          _nef_peak.chain_code_3
          _nef_peak.sequence_code_3
-         _nef_peak.residue_type_3
+         _nef_peak.residue_name_3
          _nef_peak.atom_name_3
 
          # key: ordinal
@@ -920,63 +920,63 @@ save_nef_distance_restraint_list_hbond1
          _nef_peak.position_uncertainty_15
          _nef_peak.chain_code_1
          _nef_peak.sequence_code_1
-         _nef_peak.residue_type_1
+         _nef_peak.residue_name_1
          _nef_peak.atom_name_1
          _nef_peak.chain_code_2
          _nef_peak.sequence_code_2
-         _nef_peak.residue_type_2
+         _nef_peak.residue_name_2
          _nef_peak.atom_name_2
          _nef_peak.chain_code_3
          _nef_peak.sequence_code_3
-         _nef_peak.residue_type_3
+         _nef_peak.residue_name_3
          _nef_peak.atom_name_3
          _nef_peak.chain_code_4
          _nef_peak.sequence_code_4
-         _nef_peak.residue_type_4
+         _nef_peak.residue_name_4
          _nef_peak.atom_name_4
          _nef_peak.chain_code_5
          _nef_peak.sequence_code_5
-         _nef_peak.residue_type_5
+         _nef_peak.residue_name_5
          _nef_peak.atom_name_5
          _nef_peak.chain_code_6
          _nef_peak.sequence_code_6
-         _nef_peak.residue_type_6
+         _nef_peak.residue_name_6
          _nef_peak.atom_name_6
          _nef_peak.chain_code_7
          _nef_peak.sequence_code_7
-         _nef_peak.residue_type_7
+         _nef_peak.residue_name_7
          _nef_peak.atom_name_7
          _nef_peak.chain_code_8
          _nef_peak.sequence_code_8
-         _nef_peak.residue_type_8
+         _nef_peak.residue_name_8
          _nef_peak.atom_name_8
          _nef_peak.chain_code_9
          _nef_peak.sequence_code_9
-         _nef_peak.residue_type_9
+         _nef_peak.residue_name_9
          _nef_peak.atom_name_9
          _nef_peak.chain_code_10
          _nef_peak.sequence_code_10
-         _nef_peak.residue_type_10
+         _nef_peak.residue_name_10
          _nef_peak.atom_name_10
          _nef_peak.chain_code_11
          _nef_peak.sequence_code_11
-         _nef_peak.residue_type_11
+         _nef_peak.residue_name_11
          _nef_peak.atom_name_11
          _nef_peak.chain_code_12
          _nef_peak.sequence_code_12
-         _nef_peak.residue_type_12
+         _nef_peak.residue_name_12
          _nef_peak.atom_name_12
          _nef_peak.chain_code_13
          _nef_peak.sequence_code_13
-         _nef_peak.residue_type_13
+         _nef_peak.residue_name_13
          _nef_peak.atom_name_13
          _nef_peak.chain_code_14
          _nef_peak.sequence_code_14
-         _nef_peak.residue_type_14
+         _nef_peak.residue_name_14
          _nef_peak.atom_name_14
          _nef_peak.chain_code_15
          _nef_peak.sequence_code_15
-         _nef_peak.residue_type_15
+         _nef_peak.residue_name_15
          _nef_peak.atom_name_15
       
          # key: ordinal

--- a/specification/Commented_Example.nef
+++ b/specification/Commented_Example.nef
@@ -302,7 +302,6 @@ INSERT PULSE PROGRAM HERE
 
       _nef_chemical_shift_list.sf_category                nef_chemical_shift_list
       _nef_chemical_shift_list.sf_framecode               nef_chemical_shift_list_1
-      _nef_chemical_shift_list.atom_chemical_shift_units  ppm
 
       loop_
          _nef_chemical_shift.chain_code

--- a/specification/Commented_Example.nef
+++ b/specification/Commented_Example.nef
@@ -1025,4 +1025,41 @@ save_nef_distance_restraint_list_hbond1
 
 save_
 
+
+#=======================================================================
+# Section 10
+#
+# Optional: Program-specific raw_data saveframe
+#
+# Each program-specific prefix should include the 'programspecific_raw_data'
+# saveframe as a slot to add copies of raw input files.
+#
+# The preferred option remains to use structured program-specific tags
+# to store program-specific information, but this saveframe serves as a
+# quick way to add unstructured data or input files for comparison.
+#
+#=======================================================================
+
+save_xplor_raw_data_T1_T2_values_1
+    _xplor_raw_data.sf_category     xplor_raw_data
+    _xplor_raw_data.sf_framecode    xplor_raw_data_T1_T2_values_1
+
+    # ALl items below are optional:
+    _xplor_raw_data.file_name       input_file_name.extension
+
+    _xplor_raw_data.details
+; Optional item
+For comments.
+Any multiline text can be put here
+;
+
+    _xplor_raw_data.text
+;
+If the string starts with a new line (as in this case) it is skipped. This avoids issues with how many initial spaces to strip
+;
+save_
+
+
+
+
 # End of data_nef_my_nmr_project_1

--- a/specification/Commented_Example.nef
+++ b/specification/Commented_Example.nef
@@ -276,7 +276,7 @@ INSERT PULSE PROGRAM HERE
 
          # key: chain_code_1, sequence_code_1, atom_name_1, chain_code_2, sequence_code_2, atom_name_2
 
-         A 20 CYS SG B 17 CYS SG
+         A 20 CYS SG  B 17 CYS SG
          D  2 CYS SG  D  6 CYS SG
          D  4 CYS SG  D  8 CYS SG
          E  1 ASN N   E  6 GLU CD
@@ -322,6 +322,8 @@ INSERT PULSE PROGRAM HERE
          A     15      GLY   H      7.8     0   
          A     15      GLY   N      106.5   0   
          A     15      GLY   QA     3.42    0.02
+         A     17      VAL   H      8.12    0   
+         A     17      VAL   N      116.5   0   
          A     17      VAL   CG%    22.1    0.3 
          A     17      VAL   HG%    0.73    0.02
          A     18      PHE   H      8.3     0   
@@ -330,26 +332,31 @@ INSERT PULSE PROGRAM HERE
          A     18      PHE   N      119.5   0   
          A     19      LEU   CA     172.2   0   
          A     19      LEU   CB     58.5    0   
-         A     19      LEU   CD1    22.2    0   
-         A     19      LEU   CD2    58.5    0   
-         A     19      LEU   CDX    17.4    0.3 
-         A     19      LEU   CDY    18.7    0.3 
+         A     19      LEU   CDx    17.4    0.3 
+         A     19      LEU   CDy    18.7    0.3 
          A     19      LEU   CG     32.3    0   
-         A     19      LEU   HBX    2.13    0.02
-         A     19      LEU   HBY    2.51    0.02
-         A     19      LEU   HDX%   0.87    0.02
-         A     19      LEU   HDY%   0.73    0.02
+         A     19      LEU   HBx    2.13    0.02
+         A     19      LEU   HBy    2.51    0.02
+         A     19      LEU   HDx%   0.87    0.02
+         A     19      LEU   HDy%   0.73    0.02
          A     19      LEU   HN     7.2     0   
          A     19      LEU   N      119.5   0   
-         A     20      CYS   HBX    3.2     0   
+         A     20      CYS   HBx    3.2     0   
          A     21      ALA   H      8.33    0.02
          A     21      ALA   HA     4.17    0.02
          A     21      ALA   HB%    1.34    0.02
+         A     21      ALA   N      123.4   0.4
+         A     22      THR   H      9.17    0.02
+         A     22      THR   HG2%   1.41    0.02
+         A     22      THR   HB     3.88    0.02
+         A     22      THR   N      123.4   0.4
          A     23      LYS   CA     43.2    0.25
          A     23      LYS   H      8.45    0.04
          A     23      LYS   HA     4.27    0.02
          A     23      LYS   N      123.45  0.4 
-         A     24      ASP   HBY    3.4     0   
+         A     24      ASP   H      8.79    0   
+         A     24      ASP   N      124.1   0   
+         A     24      ASP   HBy    3.4     0   
          A     24B     GLN   H      8.3     0   
          A     24B     GLN   N      119.5   0   
          A     24C     GLN   C      28.3    0   
@@ -358,20 +365,21 @@ INSERT PULSE PROGRAM HERE
          A     24C     GLN   CG     32.3    0   
          A     24D     TYR   H      8.3     0   
          A     24D     TYR   N      119.5   0   
+         E     7       SER   HB2    3.52    0
          Z     @5      GLX   H      9.1     0   
          Z     @5      GLX   N      118.3   0   
       stop_
 
 # The atom_name by itself serves to distinguish between real atoms ('HA'),
 #  pseudoatoms ('QA'), sets of atoms ('HB%'), sterospecifically assigned atoms
-# ('HB2'), and non-stereospecifically assigned atoms ('HBX').
+# ('HB2'), and non-stereospecifically assigned atoms ('HBx').
 # In the example, Phe 18 HB2/HB3 are stereospecifically assigned, while Leu 19
 # is not.
 # Gly 15 QA is a pseudoatom, i.e. an atom at the HA2/HA3 centroid with zero van
 # der Waals radius.
 # Val 17 HG%/CG% show two methyl groups that overlap in both carbon and proton
 # dimensions.
-# 19 LEU HDX% is the methyl bound to CDX (and not to CDY).
+# 19 LEU HDx% is the methyl bound to CDx (and not to CDy).
 # The last two shifts (with chain_code @2) are unassigned but observed resonances,
 
    save_
@@ -432,9 +440,9 @@ save_nef_distance_restraint_list_L1
          2  1  .  A  17  VAL  H    A  22  THR  HG2%  1  3.7  0.4  2    2.5  4.2  4.7
          3  1  .  A  18  LEU  H    A  21  ALA  HB%   1  3.7  0.4  2    2.5  4.2  4.7
          4  1  .  A  18  LEU  H    A  22  THR  HG2%  1  3.7  0.4  2    2.5  4.2  4.7
-         5  5  .  A  18  PHE  HB2  A  24  ASP  HBX   1  2.8  0.4  1.5  2    3.2  3.7
-         6  8  .  A  18  PHE  HB2  A  24  ASP  HBY   1  4.4  0.4  3.6  4.1  5.2  5.7
-         7  8  .  A  24  ASP  HBY  E   7  SER  HB2   1  4.4  0.4  3.6  4.1  5.2  5.7
+         5  5  .  A  18  PHE  HB2  A  24  ASP  HBy   1  2.8  0.4  1.5  2    3.2  3.7
+         6  8  .  A  18  PHE  HB2  A  24  ASP  HBy  1  4.4  0.4  3.6  4.1  5.2  5.7
+         7  8  .  A  24  ASP  HBy  E   7  SER  HB2   1  4.4  0.4  3.6  4.1  5.2  5.7
       stop_
 
       # The first column (index_id) is a consecutive line number that does not persist  
@@ -492,10 +500,10 @@ save_nef_distance_restraint_list_hbond1
       
          # key: index_id
 
-         1  1  .  A  15  VAL  H    A  24B  THR  O     1  1.8    .  .  1.4    2.7  .
-         2  2  .  A  15  VAL  N    A  24B  THR  O     1  2.8    .  .  2.4    3.7  .
-         3  3  1  A  13  THR  O    A  16   VAL  H     1  1.8    .  .  1.4    2.7  .
-         4  3  1  A  13  THR  O    A  16   VAL  N     1  2.8    .  .  2.4    3.7  .
+         1  1  .  A  15  GLY  H    A  24B  GLN  O     1  1.8    .  .  1.4    2.7  .
+         2  2  .  A  15  GLY  N    A  24B  GLN  O     1  2.8    .  .  2.4    3.7  .
+         3  3  1  A  13  THR  O    A  19   LEU  H     1  1.8    .  .  1.4    2.7  .
+         4  3  1  A  13  THR  O    A  19   LEU  N     1  2.8    .  .  2.4    3.7  .
          5  4  2  A  17  VAL  H    A  22   THR  O     1  1.8    .  .  1.4    2.7  .
          6  4  2  A  17  VAL  N    A  22   THR  O     1  2.8    .  .  2.4    3.7  .
          7  4  3  A  17  VAL  H    A  24   ASP  O     1  1.8    .  .  1.4    2.7  .
@@ -582,7 +590,8 @@ save_nef_distance_restraint_list_hbond1
          7   4  2  A  16  ASN  N   A  16  ASN  CA  A  16  ASN  C   A  17   VAL  N    1  -50  5  .  -60  -40  .  PSI
          8   4  3  A  15  GLY  C   A  16  ASN  N   A  16  ASN  CA  A  16   ASN  C    1  -80  5  .  -90  -70  .  PHI
          9   4  3  A  16  ASN  N   A  16  ASN  CA  A  16  ASN  C   A  17   VAL  N    1  -80  5  .  -90  -70  .  PSI
-         10  5  .  A  19  LEU  CA  A  19  LEU  CB  A  19  LEU  CG  A  19   LEU  CDX  1  -80  5  .  -90  -70  .  .  
+         10  5  .  A  19  LEU  CA  A  19  LEU  CB  A  19  LEU  CG  A  19   LEU  CDx  1  -80  5  .  -90  -70  .  .  
+         11  6  .  A  21  LYS  CA  A  21  LYS  CB  A  21  LYS  CG  A  21   LYS  CD   1  -80  5  .  -90  -70  .  CHI2
       stop_
 
       # - Restraint 1 is an ambiguous psi restraint. The atoms are the same,
@@ -800,14 +809,14 @@ save_nef_distance_restraint_list_hbond1
          # key: index_id
 
          1   1  73000000  5100000   33000000  1100000   3.2  0.05  119.5  0.5  8.3  0.03  A  14  TRP  HB3  A  18    PHE  N    A  18    PHE  H  
-         2   1  73000000  5100000   33000000  1100000   3.2  0.05  119.5  0.5  8.3  0.03  A  19  LEU  HBY  A  24B   GLN  N    A  24B   GLN  H  
-         3   1  73000000  5100000   33000000  1100000   3.2  0.05  119.5  0.5  8.3  0.03  A  19  LEU  HBY  A  24D   TYR  N    A  24D   TYR  H  
-         4   1  73000000  5100000   33000000  1100000   3.2  0.05  119.5  0.5  8.3  0.03  A  20  CYS  HBX  A  24B   GLN  N    A  24B   GLN  H  
-         5   1  73000000  5100000   33000000  1100000   3.2  0.05  119.5  0.5  8.3  0.03  A  20  CYS  HBX  A  24D   TYR  N    A  24D   TYR  H  
+         2   1  73000000  5100000   33000000  1100000   3.2  0.05  119.5  0.5  8.3  0.03  A  19  LEU  HBy  A  24B   GLN  N    A  24B   GLN  H  
+         3   1  73000000  5100000   33000000  1100000   3.2  0.05  119.5  0.5  8.3  0.03  A  19  LEU  HBy  A  24D   TYR  N    A  24D   TYR  H  
+         4   1  73000000  5100000   33000000  1100000   3.2  0.05  119.5  0.5  8.3  0.03  A  20  CYS  HBx  A  24B   GLN  N    A  24B   GLN  H  
+         5   1  73000000  5100000   33000000  1100000   3.2  0.05  119.5  0.5  8.3  0.03  A  20  CYS  HBx  A  24D   TYR  N    A  24D   TYR  H  
          6   3  54000000  7300000   34000000  5300000   4.4  0.05  106.5  0.5  7.8  0.03  .  .   .    .    A  15    GLY  N    A  15    GLY  H  
          7   4  88000000  13000000  48000000  3300000   3.2  0.05  135.6  0.5  9.9  0.03  A  14  TRP  HB3  A  14    TRP  NE1  A  14    TRP  HE1
          8   5  88000000  13000000  58000000  23000000  3.4  0.05  135.6  0.5  9.9  0.03  A  14  TRP  HB2  A  14    TRP  NE1  A  14    TRP  HE1
-         9   5  88000000  13000000  58000000  23000000  3.4  0.05  135.6  0.5  9.9  0.03  A  24  ASP  HBY  A  14    TRP  NE1  A  14    TRP  HE1
+         9   5  88000000  13000000  58000000  23000000  3.4  0.05  135.6  0.5  9.9  0.03  A  24  ASP  HBy  A  14    TRP  NE1  A  14    TRP  HE1
          10  7  59000000  7100000   29000000  6100000   1.7  0.05  118.3  0.5  9.1  0.03  .  .   .    .    Z  @5    GLX  N    Z  @5    GLX  H  
       stop_
 
@@ -980,7 +989,7 @@ save_nef_distance_restraint_list_hbond1
       
          # key: index_id
 
-         1  1  73000000  5100000  33000000  1100000  7.2  0.05  119.5  0.4  28.3  0.3  172.2  0.5  58.5  0.4  32.3  0.4  22.2  0.5  58.5  0.4  32.3  0.4  22.2  0.5  58.5  0.4  32.3  0.4  22.2  0.5  58.5  0.4  32.3  0.4  A  19  LEU  HN  A  19  LEU  N  A  24C   GLN  C  A  19  LEU  CA  A  19  LEU  CB  A  19  LEU  CG  A  19  LEU  CD1  A  19  LEU  CD2  A  19  LEU  CG  A  19  LEU  CA  A  19  LEU  CB  A  19  LEU  CG  A  24C   GLN  CA  A  24C   GLN  CB  A  24C   GLN  CG
+         1  1  73000000  5100000  33000000  1100000  7.2  0.05  119.5  0.4  28.3  0.3  172.2  0.5  58.5  0.4  32.3  0.4  22.2  0.5  58.5  0.4  32.3  0.4  22.2  0.5  58.5  0.4  32.3  0.4  22.2  0.5  58.5  0.4  32.3  0.4  A  19  LEU  HN  A  19  LEU  N  A  24C   GLN  C  A  19  LEU  CA  A  19  LEU  CB  A  19  LEU  CG  A  19  LEU  CDx  A  19  LEU  CDy  A  19  LEU  CG  A  19  LEU  CA  A  19  LEU  CB  A  19  LEU  CG  A  24C   GLN  CA  A  24C   GLN  CB  A  24C   GLN  CG
       stop_
    save_
 

--- a/specification/Overview.md
+++ b/specification/Overview.md
@@ -692,3 +692,18 @@ expressions for Threonine and applying the standard regular expression rules.
     corresponds to multiple lines in the relevant loops). Each peak can be
     linked to multiple restraints, and vice versa. Links to different types of
     restraint all share a single table.
+    
+
+  * Regarding Section 10. Optional: **Program-specific raw_data saveframe**
+  
+    1. Each program-specific namespace should include the '_programspecific_raw_data'
+    saveframe (e.g. '_cyana_raw_data', '_csrosetta_raw_data' etc. as a slot to add 
+    copies of raw input files. The preferred option remains to use structured 
+    program-specific tags to store program-specific information, but this 
+    saveframe serves as a quick way to add unstructured data or copies of input 
+    files for comparison.
+    
+    NB, being program-specific this saveframe is not specified in the mmcIf_nef.dic
+    specification file, but only shown as an example in the Commented_Example.nef
+    file. Suggestions are welcome as to how such a saveframe should be put into the
+    general nef specification.

--- a/specification/Overview.md
+++ b/specification/Overview.md
@@ -11,9 +11,10 @@ organised by data category (saveframe).
 
   1. Residue and Atom names
 
-    Residues are identified by three strings ('chain_code', 'sequence_code',
-    'residue_type') that always are used together. Atoms are identified by a
-    residue identifier plus the atom name as a fourth string.
+    Residues are identified by three strings ('chain_code' (e.g. 'A'), 'sequence_code' 
+    (e.g. ('127'), 'residue_name' (e.g. 'ALA')) that always are used together. 
+    Atoms are identified by a residue identifier plus the atom name (e.g. 'HA')
+    as a fourth string.
 
     1. The identifying strings are case sensitive, and all identifiers
     (including casing) must be consistent throughout a file. Atom names and
@@ -42,12 +43,12 @@ organised by data category (saveframe).
     a small subset of the RCSB residue variant codes (see below). It remains an
     outstanding issue whether this should be changed or expanded.
 
-    5. 'residue_type' must be specified as the basic type in all cases (e.g. use
+    5. 'residue_name' must be specified as the basic type in all cases (e.g. use
     HIS regardless of protonation state).
 
     6. A residue is uniquely identified by the 'chain_code' and 'sequence_code',
-    so that the same 'residue_type' string must be used consistently throughout
-    the file. Strictly speaking this makes the 'residue_type' string redundant,
+    so that the same 'residue_name' string must be used consistently throughout
+    the file. Strictly speaking this makes the 'residue_name' string redundant,
     but it is used in identifiers to avoid ambiguity and to serve as a
     cross-check.
 
@@ -129,7 +130,7 @@ organised by data category (saveframe).
 
     13. Selection expressions. For the time being wildcards are allowed only
     for atom names. It would be possible to extend their use to 'chain_code',
-    'sequence_code' and 'residue_type' at a later date, if there is a use case
+    'sequence_code' and 'residue_name' at a later date, if there is a use case
     for this. More complex selection expressions, such as residue ranges, are
     surely too complicated for this kind of format. Note that these can be
     expressed as ambiguous peak assignments or restraints. For the specific
@@ -383,7 +384,7 @@ expressions for Threonine and applying the standard regular expression rules.
 
     4. The '_sequence' loop is a compromise between a full, complex topology
     description and simply assuming linear polymers - see the example files,
-    section 3. The '_nef_sequence.residue_type' is always the
+    section 3. The '_nef_sequence.residue_name' is always the
     canonical name (e.g. 'HIS' regardless of protonation state or chain
     position).The '_nef_sequence.linking' column shows linear connection
     information.
@@ -448,7 +449,7 @@ expressions for Threonine and applying the standard regular expression rules.
      'LL' (middle of chain), 'LSN3' (N-terminal, protonated),
      'LEO2' (C-terminal, deprotonated), and 'LEO2H' (C-terminal, protonated).
 
-| Residue_type | dyana_type | protonation_code | example | comment |
+| residue_name | dyana_type | protonation_code | example | comment |
 |-----|:-----|:-------|-----|-----|
 | ARG | ARG  | DHH12  | ARG_LL_DHH12 | side chain deprotonated |
 | ASP | ASP  | *None* | ASP_LL | side chain protonated |
@@ -599,8 +600,8 @@ expressions for Threonine and applying the standard regular expression rules.
   * Regarding Section 7. Optional: **RDC restraint lists(s)**
 
     1. The orientation tensor is indicated by giving the 'chain_code',
-    'sequence_code', and 'residue_type' for the residue used to give the
-    orientation tensor in coordinate files. The 'residue_type' should be TNSR.
+    'sequence_code', and 'residue_name' for the residue used to give the
+    orientation tensor in coordinate files. The 'residue_name' should be TNSR.
     Tensor values are given as magnitude and rhombicity.
 
     2. The RDC restraint list can also be used to give non-reduced dipolar

--- a/specification/Overview.md
+++ b/specification/Overview.md
@@ -154,7 +154,8 @@ organised by data category (saveframe).
     5. Spectrum dimensions, peaks, restraints etc. are numbered starting at
     1 (and *not* at zero). Peaks and restraints are represented by more than one
     line in the corresponding loop; an additional column for the line number
-    ('ordinal') serves as the unique key for the loop.
+    ('index_id') serves as the unique key for the loop. These values are *not* 
+    preserved when reading and re-writing data.
 
     6. Peak numbers, restraint numbers, and datablock names / saveframe
     framecodes must  be kept unchanged by programs, so that they can be used as
@@ -462,7 +463,7 @@ expressions for Threonine and applying the standard regular expression rules.
 
   * Regarding Section 5. Optional: **Distance restraint lists(s)**
 
-    1. The ordinal column is a series of consecutive integers that serve to
+    1. The index_id column is a series of consecutive integers that serve to
     make each line unique. These values are *not* preserved when reading and
     re-writing data.
 
@@ -573,7 +574,7 @@ expressions for Threonine and applying the standard regular expression rules.
     We recommend using one of the values given below, but if these do
     not fit, others may be added. Values: 'chemical_shift', 'jcoupling'.
 
-    2. The ordinal column is a series of consecutive integers that serve to
+    2. The index_id column is a series of consecutive integers that serve to
     make each line unique. These values are *not* preserved when reading and
     re-writing data.
 
@@ -612,7 +613,7 @@ expressions for Threonine and applying the standard regular expression rules.
     not fit, others may be added. The value 'measured' should typically be
     sufficient.
 
-    4. The ordinal column is a series of consecutive integers that serve to
+    4. The index_id column is a series of consecutive integers that serve to
     make each line unique. These values are *not* preserved when reading and
     re-writing data.
 
@@ -668,7 +669,7 @@ expressions for Threonine and applying the standard regular expression rules.
     peaks, 3D peaks etc. For e.g. a 3D peak list, tags for dimensions 4 and
     higher are simply omitted. The maximum possible dimension is 15.
 
-    7. The ordinal column is a series of consecutive integers that serve to
+    7. The index_id column is a series of consecutive integers that serve to
     make each line unique. These values are *not* preserved when reading and
     re-writing data.
 

--- a/specification/mmcif_nef.dic
+++ b/specification/mmcif_nef.dic
@@ -1146,7 +1146,6 @@ save_nef_chemical_shift_list
    _category_examples.case    
 ;   _nef_chemical_shift_list.sf_category                nef_chemical_shift_list
    _nef_chemical_shift_list.sf_framecode               nef_chemical_shift_list_bmrb21_str
-   _nef_chemical_shift_list.atom_chemical_shift_units  ppm
 ;
    #
 save_
@@ -1178,21 +1177,6 @@ save__nef_chemical_shift_list.sf_framecode
    _item_type.code  nef_framecode
    #
    _item_examples.case  nef_chemical_shift_list_bmrb21_str
-   #
-save_
-#
-save__nef_chemical_shift_list.atom_chemical_shift_units
-   #
-
-   _item_description.description  "The units of chemical shift values in the NEF_CHEMICAL_SHIFT category."
-   #
-   _item.name            "_nef_chemical_shift_list.atom_chemical_shift_units"
-   _item.category_id     nef_chemical_shift_list
-   _item.mandatory_code  yes
-   #
-   _item_type.code  word
-   #
-   _item_examples.case  ppm
    #
 save_
 

--- a/specification/mmcif_nef.dic
+++ b/specification/mmcif_nef.dic
@@ -789,14 +789,14 @@ save_nef_sequence
    _category_key.name
      "_nef_sequence.chain_code"  
      "_nef_sequence.sequence_code"  
-     "_nef_sequence.residue_type"  
+     "_nef_sequence.residue_name"  
    #
    _category_examples.detail  "Example 1"
    _category_examples.case    
 ;  loop_
     _nef_sequence.chain_code
     _nef_sequence.sequence_code
-    _nef_sequence.residue_type
+    _nef_sequence.residue_name
     _nef_sequence.linking
     _nef_sequence.residue_variant
 
@@ -898,12 +898,12 @@ save__nef_sequence.sequence_code
    #
 save_
 #
-save__nef_sequence.residue_type
+save__nef_sequence.residue_name
    #
 
    _item_description.description  "The author provided residue name."
    #
-   _item.name            "_nef_sequence.residue_type"
+   _item.name            "_nef_sequence.residue_name"
    _item.category_id     nef_sequence
    _item.mandatory_code  yes
    #
@@ -978,12 +978,12 @@ save_nef_covalent_links
    loop_
    _category_key.name
      "_nef_covalent_links.chain_code_1"  
-     "_nef_covalent_links.residue_type_1"  
+     "_nef_covalent_links.residue_name_1"  
      "_nef_covalent_links.sequence_code_1"  
      "_nef_covalent_links.atom_name_1"  
      "_nef_covalent_links.chain_code_2"  
      "_nef_covalent_links.sequence_code_2"   
-     "_nef_covalent_links.residue_type_2" 
+     "_nef_covalent_links.residue_name_2" 
      "_nef_covalent_links.atom_name_2"  
    #
    _category_examples.detail  "Example 1"
@@ -991,11 +991,11 @@ save_nef_covalent_links
 ;   loop_
      _nef_covalent_links.chain_code_1
      _nef_covalent_links.sequence_code_1
-     _nef_covalent_links.residue_type_1
+     _nef_covalent_links.residue_name_1
      _nef_covalent_links.atom_name_1
      _nef_covalent_links.chain_code_2
      _nef_covalent_links.sequence_code_2
-     _nef_covalent_links.residue_type_2
+     _nef_covalent_links.residue_name_2
      _nef_covalent_links.atom_name_2
      B   3   CYS   SG   B   6   CYS   SG
      B   5   THR   OG1  B   9   GLN   C
@@ -1034,12 +1034,12 @@ save__nef_covalent_links.sequence_code_1
    #
 save_
 #
-save__nef_covalent_links.residue_type_1
+save__nef_covalent_links.residue_name_1
    #
 
    _item_description.description  "The author provided name for the first partner residue."
    #
-   _item.name            "_nef_covalent_links.residue_type_1"
+   _item.name            "_nef_covalent_links.residue_name_1"
    _item.category_id     nef_covalent_links
    _item.mandatory_code  yes
    #
@@ -1094,12 +1094,12 @@ save__nef_covalent_links.sequence_code_2
    #
 save_
 #
-save__nef_covalent_links.residue_type_2
+save__nef_covalent_links.residue_name_2
    #
 
    _item_description.description  "The author provided name for the second partner residue."
    #
-   _item.name            "_nef_covalent_links.residue_type_2"
+   _item.name            "_nef_covalent_links.residue_name_2"
    _item.category_id     nef_covalent_links
    _item.mandatory_code  yes
    #
@@ -1211,7 +1211,7 @@ save_nef_chemical_shift
    _category_key.name  
      "_nef_chemical_shift.chain_code"  
      "_nef_chemical_shift.sequence_code"  
-     "_nef_chemical_shift.residue_type"  
+     "_nef_chemical_shift.residue_name"  
      "_nef_chemical_shift.atom_name"
    #
    _category_examples.detail  "Example 1"
@@ -1219,7 +1219,7 @@ save_nef_chemical_shift
 ;   loop_
       _nef_chemical_shift.chain_code
       _nef_chemical_shift.sequence_code
-      _nef_chemical_shift.residue_type
+      _nef_chemical_shift.residue_name
       _nef_chemical_shift.atom_name
       _nef_chemical_shift.value
       _nef_chemical_shift.value_uncertainty
@@ -1297,12 +1297,12 @@ save__nef_chemical_shift.sequence_code
    #
 save_
 #
-save__nef_chemical_shift.residue_type
+save__nef_chemical_shift.residue_name
    #
 
    _item_description.description  "The author provided residue name."
    #
-   _item.name            "_nef_chemical_shift.residue_type"
+   _item.name            "_nef_chemical_shift.residue_name"
    _item.category_id     nef_chemical_shift
    _item.mandatory_code  yes
    #
@@ -1473,11 +1473,11 @@ save_nef_distance_restraint
     _nef_distance_restraint.restraint_combination_id
     _nef_distance_restraint.chain_code_1
     _nef_distance_restraint.sequence_code_1
-    _nef_distance_restraint.residue_type_1
+    _nef_distance_restraint.residue_name_1
     _nef_distance_restraint.atom_name_1
     _nef_distance_restraint.chain_code_2
     _nef_distance_restraint.sequence_code_2
-    _nef_distance_restraint.residue_type_2
+    _nef_distance_restraint.residue_name_2
     _nef_distance_restraint.atom_name_2
     _nef_distance_restraint.weight
     _nef_distance_restraint.target_value
@@ -1592,12 +1592,12 @@ save__nef_distance_restraint.sequence_code_1
    #
 save_
 #
-save__nef_distance_restraint.residue_type_1
+save__nef_distance_restraint.residue_name_1
    #
 
    _item_description.description  "The author provided name for the first partner residue."
    #
-   _item.name            "_nef_distance_restraint.residue_type_1"
+   _item.name            "_nef_distance_restraint.residue_name_1"
    _item.category_id     nef_distance_restraint
    _item.mandatory_code  yes
    #
@@ -1652,12 +1652,12 @@ save__nef_distance_restraint.sequence_code_2
    #
 save_
 #
-save__nef_distance_restraint.residue_type_2
+save__nef_distance_restraint.residue_name_2
    #
 
    _item_description.description  "The author provided name for the second partner residue."
    #
-   _item.name            "_nef_distance_restraint.residue_type_2"
+   _item.name            "_nef_distance_restraint.residue_name_2"
    _item.category_id     nef_distance_restraint
    _item.mandatory_code  yes
    #
@@ -1899,19 +1899,19 @@ save_nef_dihedral_restraint
     _nef_dihedral_restraint.restraint_combination_id
     _nef_dihedral_restraint.chain_code_1
     _nef_dihedral_restraint.sequence_code_1
-    _nef_dihedral_restraint.residue_type_1
+    _nef_dihedral_restraint.residue_name_1
     _nef_dihedral_restraint.atom_name_1
     _nef_dihedral_restraint.chain_code_2
     _nef_dihedral_restraint.sequence_code_2
-    _nef_dihedral_restraint.residue_type_2
+    _nef_dihedral_restraint.residue_name_2
     _nef_dihedral_restraint.atom_name_2
     _nef_dihedral_restraint.chain_code_3
     _nef_dihedral_restraint.sequence_code_3
-    _nef_dihedral_restraint.residue_type_3
+    _nef_dihedral_restraint.residue_name_3
     _nef_dihedral_restraint.atom_name_3
     _nef_dihedral_restraint.chain_code_4
     _nef_dihedral_restraint.sequence_code_4
-    _nef_dihedral_restraint.residue_type_4
+    _nef_dihedral_restraint.residue_name_4
     _nef_dihedral_restraint.atom_name_4
     _nef_dihedral_restraint.weight
     _nef_dihedral_restraint.target_value
@@ -2019,12 +2019,12 @@ save__nef_dihedral_restraint.sequence_code_1
    #
 save_
 #
-save__nef_dihedral_restraint.residue_type_1
+save__nef_dihedral_restraint.residue_name_1
    #
 
    _item_description.description  "The author provided name for the first partner residue."
    #
-   _item.name            "_nef_dihedral_restraint.residue_type_1"
+   _item.name            "_nef_dihedral_restraint.residue_name_1"
    _item.category_id     nef_dihedral_restraint
    _item.mandatory_code  yes
    #
@@ -2079,12 +2079,12 @@ save__nef_dihedral_restraint.sequence_code_2
    #
 save_
 #
-save__nef_dihedral_restraint.residue_type_2
+save__nef_dihedral_restraint.residue_name_2
    #
 
    _item_description.description  "The author provided name for the second partner residue."
    #
-   _item.name            "_nef_dihedral_restraint.residue_type_2"
+   _item.name            "_nef_dihedral_restraint.residue_name_2"
    _item.category_id     nef_dihedral_restraint
    _item.mandatory_code  yes
    #
@@ -2139,12 +2139,12 @@ save__nef_dihedral_restraint.sequence_code_3
    #
 save_
 #
-save__nef_dihedral_restraint.residue_type_3
+save__nef_dihedral_restraint.residue_name_3
    #
 
    _item_description.description  "The author provided name for the third partner residue."
    #
-   _item.name            "_nef_dihedral_restraint.residue_type_3"
+   _item.name            "_nef_dihedral_restraint.residue_name_3"
    _item.category_id     nef_dihedral_restraint
    _item.mandatory_code  yes
    #
@@ -2199,12 +2199,12 @@ save__nef_dihedral_restraint.sequence_code_4
    #
 save_
 #
-save__nef_dihedral_restraint.residue_type_4
+save__nef_dihedral_restraint.residue_name_4
    #
 
    _item_description.description  "The author provided name for the fourth partner residue."
    #
-   _item.name            "_nef_dihedral_restraint.residue_type_4"
+   _item.name            "_nef_dihedral_restraint.residue_name_4"
    _item.category_id     nef_dihedral_restraint
    _item.mandatory_code  yes
    #
@@ -2498,12 +2498,12 @@ save__nef_rdc_restraint_list.tensor_sequence_code
    #
 save_
 #
-save__nef_rdc_restraint_list.tensor_residue_type
+save__nef_rdc_restraint_list.tensor_residue_name
    #
 
    _item_description.description  "The author provided residue code for a dummy residue specifying the location and orientation of the tensor."
    #
-   _item.name            "_nef_rdc_restraint_list.tensor_residue_type"
+   _item.name            "_nef_rdc_restraint_list.tensor_residue_name"
    _item.category_id     nef_rdc_restraint_list
    _item.mandatory_code  no
    #
@@ -2535,11 +2535,11 @@ save_nef_rdc_restraint
     _nef_rdc_restraint.restraint_combination_id
     _nef_rdc_restraint.chain_code_1
     _nef_rdc_restraint.sequence_code_1
-    _nef_rdc_restraint.residue_type_1
+    _nef_rdc_restraint.residue_name_1
     _nef_rdc_restraint.atom_name_1
     _nef_rdc_restraint.chain_code_2
     _nef_rdc_restraint.sequence_code_2
-    _nef_rdc_restraint.residue_type_2
+    _nef_rdc_restraint.residue_name_2
     _nef_rdc_restraint.atom_name_2
     _nef_rdc_restraint.weight
     _nef_rdc_restraint.target_value
@@ -2636,12 +2636,12 @@ save__nef_rdc_restraint.sequence_code_1
    #
 save_
 #
-save__nef_rdc_restraint.residue_type_1
+save__nef_rdc_restraint.residue_name_1
    #
 
    _item_description.description  "The author provided name for the first partner residue."
    #
-   _item.name            "_nef_rdc_restraint.residue_type_1"
+   _item.name            "_nef_rdc_restraint.residue_name_1"
    _item.category_id     nef_rdc_restraint
    _item.mandatory_code  yes
    #
@@ -2696,12 +2696,12 @@ save__nef_rdc_restraint.sequence_code_2
    #
 save_
 #
-save__nef_rdc_restraint.residue_type_2
+save__nef_rdc_restraint.residue_name_2
    #
 
    _item_description.description  "The author provided name for the second partner residue."
    #
-   _item.name            "_nef_rdc_restraint.residue_type_2"
+   _item.name            "_nef_rdc_restraint.residue_name_2"
    _item.category_id     nef_rdc_restraint
    _item.mandatory_code  yes
    #
@@ -3318,15 +3318,15 @@ save_nef_peak
       _nef_peak.position_uncertainty_3
       _nef_peak.chain_code_1
       _nef_peak.sequence_code_1
-      _nef_peak.residue_type_1
+      _nef_peak.residue_name_1
       _nef_peak.atom_name_1
       _nef_peak.chain_code_2
       _nef_peak.sequence_code_2
-      _nef_peak.residue_type_2
+      _nef_peak.residue_name_2
       _nef_peak.atom_name_2
       _nef_peak.chain_code_3
       _nef_peak.sequence_code_3
-      _nef_peak.residue_type_3
+      _nef_peak.residue_name_3
       _nef_peak.atom_name_3
 
   #key: ordinal
@@ -3383,63 +3383,63 @@ save_nef_peak
       _nef_peak.position_uncertainty_15
       _nef_peak.chain_code_1
       _nef_peak.sequence_code_1
-      _nef_peak.residue_type_1
+      _nef_peak.residue_name_1
       _nef_peak.atom_name_1
       _nef_peak.chain_code_2
       _nef_peak.sequence_code_2
-      _nef_peak.residue_type_2
+      _nef_peak.residue_name_2
       _nef_peak.atom_name_2
       _nef_peak.chain_code_3
       _nef_peak.sequence_code_3
-      _nef_peak.residue_type_3
+      _nef_peak.residue_name_3
       _nef_peak.atom_name_3
       _nef_peak.chain_code_4
       _nef_peak.sequence_code_4
-      _nef_peak.residue_type_4
+      _nef_peak.residue_name_4
       _nef_peak.atom_name_4
       _nef_peak.chain_code_5
       _nef_peak.sequence_code_5
-      _nef_peak.residue_type_5
+      _nef_peak.residue_name_5
       _nef_peak.atom_name_5
       _nef_peak.chain_code_6
       _nef_peak.sequence_code_6
-      _nef_peak.residue_type_6
+      _nef_peak.residue_name_6
       _nef_peak.atom_name_6
       _nef_peak.chain_code_7
       _nef_peak.sequence_code_7
-      _nef_peak.residue_type_7
+      _nef_peak.residue_name_7
       _nef_peak.atom_name_7
       _nef_peak.chain_code_8
       _nef_peak.sequence_code_8
-      _nef_peak.residue_type_8
+      _nef_peak.residue_name_8
       _nef_peak.atom_name_8
       _nef_peak.chain_code_9
       _nef_peak.sequence_code_9
-      _nef_peak.residue_type_9
+      _nef_peak.residue_name_9
       _nef_peak.atom_name_9
       _nef_peak.chain_code_10
       _nef_peak.sequence_code_10
-      _nef_peak.residue_type_10
+      _nef_peak.residue_name_10
       _nef_peak.atom_name_10
       _nef_peak.chain_code_11
       _nef_peak.sequence_code_11
-      _nef_peak.residue_type_11
+      _nef_peak.residue_name_11
       _nef_peak.atom_name_11
       _nef_peak.chain_code_12
       _nef_peak.sequence_code_12
-      _nef_peak.residue_type_12
+      _nef_peak.residue_name_12
       _nef_peak.atom_name_12
       _nef_peak.chain_code_13
       _nef_peak.sequence_code_13
-      _nef_peak.residue_type_13
+      _nef_peak.residue_name_13
       _nef_peak.atom_name_13
       _nef_peak.chain_code_14
       _nef_peak.sequence_code_14
-      _nef_peak.residue_type_14
+      _nef_peak.residue_name_14
       _nef_peak.atom_name_14
       _nef_peak.chain_code_15
       _nef_peak.sequence_code_15
-      _nef_peak.residue_type_15
+      _nef_peak.residue_name_15
       _nef_peak.atom_name_15
 
 
@@ -4022,12 +4022,12 @@ save__nef_peak.sequence_code_1
    #
 save_
 #
-save__nef_peak.residue_type_1
+save__nef_peak.residue_name_1
    #
 
    _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 1 of the spectrum."
    #
-   _item.name            "_nef_peak.residue_type_1"
+   _item.name            "_nef_peak.residue_name_1"
    _item.category_id     nef_peak
    _item.mandatory_code  no
    #
@@ -4083,12 +4083,12 @@ save__nef_peak.sequence_code_2
    #
 save_
 #
-save__nef_peak.residue_type_2
+save__nef_peak.residue_name_2
    #
 
    _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 2 of the spectrum."
    #
-   _item.name            "_nef_peak.residue_type_2"
+   _item.name            "_nef_peak.residue_name_2"
    _item.category_id     nef_peak
    _item.mandatory_code  no
    #
@@ -4144,12 +4144,12 @@ save__nef_peak.sequence_code_3
    #
 save_
 #
-save__nef_peak.residue_type_3
+save__nef_peak.residue_name_3
    #
 
    _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 3 of the spectrum."
    #
-   _item.name            "_nef_peak.residue_type_3"
+   _item.name            "_nef_peak.residue_name_3"
    _item.category_id     nef_peak
    _item.mandatory_code  no
    #
@@ -4205,12 +4205,12 @@ save__nef_peak.sequence_code_4
    #
 save_
 #
-save__nef_peak.residue_type_4
+save__nef_peak.residue_name_4
    #
 
    _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 4 of the spectrum."
    #
-   _item.name            "_nef_peak.residue_type_4"
+   _item.name            "_nef_peak.residue_name_4"
    _item.category_id     nef_peak
    _item.mandatory_code  no
    #
@@ -4266,12 +4266,12 @@ save__nef_peak.sequence_code_5
    #
 save_
 #
-save__nef_peak.residue_type_5
+save__nef_peak.residue_name_5
    #
 
    _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 5 of the spectrum."
    #
-   _item.name            "_nef_peak.residue_type_5"
+   _item.name            "_nef_peak.residue_name_5"
    _item.category_id     nef_peak
    _item.mandatory_code  no
    #
@@ -4327,12 +4327,12 @@ save__nef_peak.sequence_code_6
    #
 save_
 #
-save__nef_peak.residue_type_6
+save__nef_peak.residue_name_6
    #
 
    _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 6 of the spectrum."
    #
-   _item.name            "_nef_peak.residue_type_6"
+   _item.name            "_nef_peak.residue_name_6"
    _item.category_id     nef_peak
    _item.mandatory_code  no
    #
@@ -4388,12 +4388,12 @@ save__nef_peak.sequence_code_7
    #
 save_
 #
-save__nef_peak.residue_type_7
+save__nef_peak.residue_name_7
    #
 
    _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 7 of the spectrum."
    #
-   _item.name            "_nef_peak.residue_type_7"
+   _item.name            "_nef_peak.residue_name_7"
    _item.category_id     nef_peak
    _item.mandatory_code  no
    #
@@ -4449,12 +4449,12 @@ save__nef_peak.sequence_code_8
    #
 save_
 #
-save__nef_peak.residue_type_8
+save__nef_peak.residue_name_8
    #
 
    _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 8 of the spectrum."
    #
-   _item.name            "_nef_peak.residue_type_8"
+   _item.name            "_nef_peak.residue_name_8"
    _item.category_id     nef_peak
    _item.mandatory_code  no
    #
@@ -4510,12 +4510,12 @@ save__nef_peak.sequence_code_9
    #
 save_
 #
-save__nef_peak.residue_type_9
+save__nef_peak.residue_name_9
    #
 
    _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 9 of the spectrum."
    #
-   _item.name            "_nef_peak.residue_type_9"
+   _item.name            "_nef_peak.residue_name_9"
    _item.category_id     nef_peak
    _item.mandatory_code  no
    #
@@ -4571,12 +4571,12 @@ save__nef_peak.sequence_code_10
    #
 save_
 #
-save__nef_peak.residue_type_10
+save__nef_peak.residue_name_10
    #
 
    _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 10 of the spectrum."
    #
-   _item.name            "_nef_peak.residue_type_10"
+   _item.name            "_nef_peak.residue_name_10"
    _item.category_id     nef_peak
    _item.mandatory_code  no
    #
@@ -4632,12 +4632,12 @@ save__nef_peak.sequence_code_11
    #
 save_
 #
-save__nef_peak.residue_type_11
+save__nef_peak.residue_name_11
    #
 
    _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 11 of the spectrum."
    #
-   _item.name            "_nef_peak.residue_type_11"
+   _item.name            "_nef_peak.residue_name_11"
    _item.category_id     nef_peak
    _item.mandatory_code  no
    #
@@ -4693,12 +4693,12 @@ save__nef_peak.sequence_code_12
    #
 save_
 #
-save__nef_peak.residue_type_12
+save__nef_peak.residue_name_12
    #
 
    _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 12 of the spectrum."
    #
-   _item.name            "_nef_peak.residue_type_12"
+   _item.name            "_nef_peak.residue_name_12"
    _item.category_id     nef_peak
    _item.mandatory_code  no
    #
@@ -4754,12 +4754,12 @@ save__nef_peak.sequence_code_13
    #
 save_
 #
-save__nef_peak.residue_type_13
+save__nef_peak.residue_name_13
    #
 
    _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 13 of the spectrum."
    #
-   _item.name            "_nef_peak.residue_type_13"
+   _item.name            "_nef_peak.residue_name_13"
    _item.category_id     nef_peak
    _item.mandatory_code  no
    #
@@ -4815,12 +4815,12 @@ save__nef_peak.sequence_code_14
    #
 save_
 #
-save__nef_peak.residue_type_14
+save__nef_peak.residue_name_14
    #
 
    _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 14 of the spectrum."
    #
-   _item.name            "_nef_peak.residue_type_14"
+   _item.name            "_nef_peak.residue_name_14"
    _item.category_id     nef_peak
    _item.mandatory_code  no
    #
@@ -4876,12 +4876,12 @@ save__nef_peak.sequence_code_15
    #
 save_
 #
-save__nef_peak.residue_type_15
+save__nef_peak.residue_name_15
    #
 
    _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 15 of the spectrum."
    #
-   _item.name            "_nef_peak.residue_type_15"
+   _item.name            "_nef_peak.residue_name_15"
    _item.category_id     nef_peak
    _item.mandatory_code  no
    #

--- a/specification/mmcif_nef.dic
+++ b/specification/mmcif_nef.dic
@@ -1463,12 +1463,12 @@ save_nef_distance_restraint
    #
    _category_group.id             nef_group
    #   #
-   _category_key.name             '_nef_distance_restraint.ordinal'
+   _category_key.name             '_nef_distance_restraint.index_id'
    #
    _category_examples.detail  "Example 1"
    _category_examples.case    
 ;  loop_
-    _nef_distance_restraint.ordinal
+    _nef_distance_restraint.index_id
     _nef_distance_restraint.restraint_id
     _nef_distance_restraint.restraint_combination_id
     _nef_distance_restraint.chain_code_1
@@ -1496,7 +1496,7 @@ save_nef_distance_restraint
     6  8  .   E 6B   SER  HB2  A 24  ASP  HBY 1.00 4.4  0.4   3.6  4.1  5.2  5.7
   stop_
 
-  # The first column (ordinal) is a consecutive line number that does not persist  
+  # The first column (index_id) is a consecutive line number that does not persist  
   # when data are re-exported
   # The second column gives the restraint ID.
   # Lines 9cxontgributions) with the same restraint_id are combined into a single restraint
@@ -1512,12 +1512,12 @@ save_nef_distance_restraint
    #
 save_
 #
-save__nef_distance_restraint.ordinal
+save__nef_distance_restraint.index_id
    #
 
    _item_description.description  "Line number for the restraint loop - not preserved when data are read."
    #
-   _item.name            "_nef_distance_restraint.ordinal"
+   _item.name            "_nef_distance_restraint.index_id"
    _item.category_id     nef_distance_restraint
    _item.mandatory_code  yes
    #
@@ -1889,12 +1889,12 @@ save_nef_dihedral_restraint
    #
    _category_group.id  nef_group
    #
-   _category_key.name  "_nef_dihedral_restraint.ordinal"
+   _category_key.name  "_nef_dihedral_restraint.index_id"
    #
    _category_examples.detail  "Example 1"
    _category_examples.case    
 ;  loop_
-    _nef_dihedral_restraint.ordinal
+    _nef_dihedral_restraint.index_id
     _nef_dihedral_restraint.restraint_id
     _nef_dihedral_restraint.restraint_combination_id
     _nef_dihedral_restraint.chain_code_1
@@ -1936,12 +1936,12 @@ stop_
    #
 save_
 
-save__nef_dihedral_restraint.ordinal
+save__nef_dihedral_restraint.index_id
    #
 
    _item_description.description  "Line number for the restraint loop - not preserved when data are read."
    #
-   _item.name            "_nef_dihedral_restraint.ordinal"
+   _item.name            "_nef_dihedral_restraint.index_id"
    _item.category_id     nef_dihedral_restraint
    _item.mandatory_code  yes
    #
@@ -2524,13 +2524,13 @@ save_nef_rdc_restraint
    #
    _category_group.id             nef_group
    #
-   _category_key.name             '_nef_rdc_restraint.ordinal'
+   _category_key.name             '_nef_rdc_restraint.index_id'
    #
    _category_examples.detail      "Example 1"
    _category_examples.case    
 ;
   loop_
-    _nef_rdc_restraint.ordinal
+    _nef_rdc_restraint.index_id
     _nef_rdc_restraint.restraint_id
     _nef_rdc_restraint.restraint_combination_id
     _nef_rdc_restraint.chain_code_1
@@ -2559,12 +2559,12 @@ save_nef_rdc_restraint
    #
 save_
 #
-save__nef_rdc_restraint.ordinal
+save__nef_rdc_restraint.index_id
    #
 
    _item_description.description  "Line number for the restraint loop - not preserved when data are read."
    #
-   _item.name            "_nef_rdc_restraint.ordinal"
+   _item.name            "_nef_rdc_restraint.index_id"
    _item.category_id     nef_rdc_restraint
    _item.mandatory_code  yes
    #
@@ -3295,7 +3295,7 @@ save_nef_peak
    #
    _category_group.id             nef_group
    #
-   _category_key.name             "_nef_peak.ordinal"
+   _category_key.name             "_nef_peak.index_id"
    #
    loop_
       _category_examples.detail     
@@ -3304,7 +3304,7 @@ save_nef_peak
 ;
   loop_
 
-      _nef_peak.ordinal
+      _nef_peak.index_id
       _nef_peak.peak_id
       _nef_peak.volume
       _nef_peak.volume_uncertainty
@@ -3329,7 +3329,7 @@ save_nef_peak
       _nef_peak.residue_name_3
       _nef_peak.atom_name_3
 
-  #key: ordinal
+  #key: index_id
 
  1  1 7.3E7 5.1E6 3.3E7 1.1E6  3.2 0.05 119.5 0.5 8.3 0.03 A 19 LEU HBY A 17 GLN N   A 17 GLN H
  2  1 7.3E7 5.1E6 3.3E7 1.1E6  3.2 0.05 119.5 0.5 8.3 0.03 A 20 CYS HBX A 17 GLN N   A 17 GLN H
@@ -3345,7 +3345,7 @@ save_nef_peak
 ;
        "Example 2"
 ;   loop_
-      _nef_peak.ordinal
+      _nef_peak.index_id
       _nef_peak.peak_id
       _nef_peak.volume
       _nef_peak.volume_uncertainty
@@ -3452,12 +3452,12 @@ save_nef_peak
    #
 save_
 #
-save__nef_peak.ordinal
+save__nef_peak.index_id
    #
    
    _item_description.description  "Line number for the peak loop - not preserved when data are read."
    #
-   _item.name            "_nef_peak.ordinal"
+   _item.name            "_nef_peak.index_id"
    _item.category_id     nef_peak
    _item.mandatory_code  yes
    #


### PR DESCRIPTION
This pull request bundles two changes (sorry). 

1_ add _programnamespace_raw_data saveframe, a standard saveframe in program-specific namespace,
to save input file contents and unstructured data.
1. Change atom names:
   a. Accept only upper case atom names as matches to molecule
   b., Change non-stereo-assignment wildcards from X/Y (upper case) to x/y (lower case)
   c. Tighten rules for accepted wildcard expressions.
