### PR TITLE
New isotope specification system

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,13 @@
 Change log
 ==========
 
+**Proposal multiple changes**
+
+* Add program_specific_raw_data saveframe
+* Change nonsereospecific wildcards from X/Y (upper case) to x/y (lower case)
+* Tighten allowed wildcards
+* Improve consistency of COmmented_Example
+
 **Proposal remove_chemical_shift_units**
 
 * Remove  _nef_chemical_shift_list.atom_chemical_shift_units tag

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,10 @@
 Change log
 ==========
 
+**Proposal remove_chemical_shift_units**
+
+* Remove  _nef_chemical_shift_list.atom_chemical_shift_units tag
+
 **Proposal ordinal_to_index_id**
 
 * change 'ordinal' to 'index_id' 

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,15 @@
 Change log
 ==========
 
+**Proposal ordinal_to_index_id**
+
+* change 'ordinal' to 'index_id' 
+(preserving _nef_run_history.run_ordinal, which *does* signify an ordering)
+
+**Proposal residue_type_to_name**
+
+* change 'residue_type' to 'residue_name' in all occurrences and tags
+
 **Version 0.2**
 
 * Version 0.2 (unfortunately named) is the final, cleaned-up version before

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,18 @@
 Change log
 ==========
 
+
+**Proposal new_residue_variants**
+
+* Change variant specification from RCSB codes to form tha lista added and subtracted atoms
+
+* Add _nef_sequence.cis_peptide column to specify peptide obnd cis/trans state.
+
+* Add specifications/Residue_Variants.txt listing all supported standard residue variants
+
+* Add example of non-stadard modified residue
+
+
 **Proposal add_nef_sequence_ordinal**
 
 * Add ordinal column to nef_sequence loop to recflect the (significant) line order.

--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,12 @@ Change log
 ==========
 
 
+**Proposal new_isotope_specification**
+
+* Added _nef_chemical_shift.element and _nef_chemical_shift.isotope_number columns
+  to specify isotope and elements with two letter element codes.
+
+
 **Proposal change_sequence_linking**
 
 * Changed rules for 'break' linking type, making it simper t0 specify sequences with breaks

--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,14 @@ Change log
 ==========
 
 
+**Proposal change_sequence_linking**
+
+* Changed rules for 'break' linking type, making it simper t0 specify sequences with breaks
+
+* Removed 'nonlinear' linking type - now using 'single' for all residue types instead.
+
+
+
 **Proposal new_residue_variants**
 
 * Change variant specification from RCSB codes to form tha lista added and subtracted atoms

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,10 @@
 Change log
 ==========
 
+**Proposal add_nef_sequence_ordinal**
+
+* Add ordinal column to nef_sequence loop to recflect the (significant) line order.
+
 **Proposal multiple changes**
 
 * Add program_specific_raw_data saveframe

--- a/specification/Commented_Example.nef
+++ b/specification/Commented_Example.nef
@@ -404,7 +404,7 @@ save_nef_distance_restraint_list_L1
 
       loop_
          # Mandatory parameters, except for restraint_combination_id
-         _nef_distance_restraint.ordinal
+         _nef_distance_restraint.index_id
          _nef_distance_restraint.restraint_id
          _nef_distance_restraint.restraint_combination_id
          _nef_distance_restraint.chain_code_1
@@ -427,7 +427,7 @@ save_nef_distance_restraint_list_L1
          _nef_distance_restraint.upper_limit
          _nef_distance_restraint.upper_linear_limit
       
-         # key: ordinal
+         # key: index_id
 
          1  1  .  A  17  VAL  H    A  21  ALA  HB%   1  3.7  0.4  2    2.5  4.2  4.7
          2  1  .  A  17  VAL  H    A  22  THR  HG2%  1  3.7  0.4  2    2.5  4.2  4.7
@@ -438,7 +438,7 @@ save_nef_distance_restraint_list_L1
          7  8  .  A  24  ASP  HBY  E   7  SER  HB2   1  4.4  0.4  3.6  4.1  5.2  5.7
       stop_
 
-      # The first column (ordinal) is a consecutive line number that does not persist  
+      # The first column (index_id) is a consecutive line number that does not persist  
       # when data are re-exported
       # The second column gives the restraint ID.
       # Lines with the same restraint_id are combined into a single restraint
@@ -468,7 +468,7 @@ save_nef_distance_restraint_list_hbond1
 
       loop_
          # Mandatory parameters, except for restraint_combination_id
-         _nef_distance_restraint.ordinal
+         _nef_distance_restraint.index_id
          _nef_distance_restraint.restraint_id
          _nef_distance_restraint.restraint_combination_id
          _nef_distance_restraint.chain_code_1
@@ -491,7 +491,7 @@ save_nef_distance_restraint_list_hbond1
          _nef_distance_restraint.upper_limit
          _nef_distance_restraint.upper_linear_limit
       
-         # key: ordinal
+         # key: index_id
 
          1  1  .  A  15  VAL  H    A  24B  THR  O     1  1.8    .  .  1.4    2.7  .
          2  2  .  A  15  VAL  N    A  24B  THR  O     1  2.8    .  .  2.4    3.7  .
@@ -503,7 +503,7 @@ save_nef_distance_restraint_list_hbond1
          8  4  3  A  17  VAL  N    A  24   ASP  O     1  2.8    .  .  2.4    3.7  .
       stop_
 
-      # The first column (ordinal) is a consecutive line number that does not persist  
+      # The first column (index_id) is a consecutive line number that does not persist  
       # when data are re-exported
       # The second column gives the restraint ID.
       # Lines with the same restraint_id are combined into a single restraint
@@ -540,7 +540,7 @@ save_nef_distance_restraint_list_hbond1
 
       loop_
          # Mandatory parameters, except for restraint_combination_id
-         _nef_dihedral_restraint.ordinal
+         _nef_dihedral_restraint.index_id
          _nef_dihedral_restraint.restraint_id
          _nef_dihedral_restraint.restraint_combination_id
          _nef_dihedral_restraint.chain_code_1
@@ -572,7 +572,7 @@ save_nef_distance_restraint_list_hbond1
          _nef_dihedral_restraint.upper_linear_limit
          _nef_dihedral_restraint.name
       
-         # key: ordinal
+         # key: index_id
          
          1   1  .  A  21  ALA  N   A  21  ALA  CA  A  21  ALA  C   A  22   THR  N    1  -50  5  .  -60  -40  .  PSI
          2   1  .  A  21  ALA  N   A  21  ALA  CA  A  21  ALA  C   A  22   THR  N    1  105  5  .  90   120  .  PSI
@@ -638,7 +638,7 @@ save_nef_distance_restraint_list_hbond1
 
       loop_
          # Mandatory parameters, except for restraint_combination_id
-         _nef_rdc_restraint.ordinal
+         _nef_rdc_restraint.index_id
          _nef_rdc_restraint.restraint_id
          _nef_rdc_restraint.restraint_combination_id
          _nef_rdc_restraint.chain_code_1
@@ -665,7 +665,7 @@ save_nef_distance_restraint_list_hbond1
          _nef_rdc_restraint.scale
          _nef_rdc_restraint.distance_dependent
 
-         # key: ordinal
+         # key: index_id
 
          1  1  .  A  21  ALA  H  A  21  ALA  N  1  -5.2  0.33  .  .  .  .  1  false
          2  2  .  A  22  THR  H  A  22  THR  N  1  3.1   0.4   .  .  .  .  1  false
@@ -773,7 +773,7 @@ save_nef_distance_restraint_list_hbond1
       # Dimensions are given in the order of the _nef_Spectrum.dimension_id defined above.
 
       loop_
-         _nef_peak.ordinal
+         _nef_peak.index_id
          _nef_peak.peak_id
          _nef_peak.volume
          _nef_peak.volume_uncertainty
@@ -798,7 +798,7 @@ save_nef_distance_restraint_list_hbond1
          _nef_peak.residue_name_3
          _nef_peak.atom_name_3
 
-         # key: ordinal
+         # key: index_id
 
          1   1  73000000  5100000   33000000  1100000   3.2  0.05  119.5  0.5  8.3  0.03  A  14  TRP  HB3  A  18    PHE  N    A  18    PHE  H  
          2   1  73000000  5100000   33000000  1100000   3.2  0.05  119.5  0.5  8.3  0.03  A  19  LEU  HBY  A  24B   GLN  N    A  24B   GLN  H  
@@ -882,7 +882,7 @@ save_nef_distance_restraint_list_hbond1
       # and ignore spectra of too high dimensionality
 
       loop_
-         _nef_peak.ordinal
+         _nef_peak.index_id
          _nef_peak.peak_id
          _nef_peak.volume
          _nef_peak.volume_uncertainty
@@ -979,7 +979,7 @@ save_nef_distance_restraint_list_hbond1
          _nef_peak.residue_name_15
          _nef_peak.atom_name_15
       
-         # key: ordinal
+         # key: index_id
 
          1  1  73000000  5100000  33000000  1100000  7.2  0.05  119.5  0.4  28.3  0.3  172.2  0.5  58.5  0.4  32.3  0.4  22.2  0.5  58.5  0.4  32.3  0.4  22.2  0.5  58.5  0.4  32.3  0.4  22.2  0.5  58.5  0.4  32.3  0.4  A  19  LEU  HN  A  19  LEU  N  A  24C   GLN  C  A  19  LEU  CA  A  19  LEU  CB  A  19  LEU  CG  A  19  LEU  CD1  A  19  LEU  CD2  A  19  LEU  CG  A  19  LEU  CA  A  19  LEU  CB  A  19  LEU  CG  A  24C   GLN  CA  A  24C   GLN  CB  A  24C   GLN  CG
       stop_

--- a/specification/Commented_Example.nef
+++ b/specification/Commented_Example.nef
@@ -159,7 +159,7 @@ INSERT PULSE PROGRAM HERE
 	 # mandatory parameters
          _nef_sequence.chain_code
          _nef_sequence.sequence_code
-         _nef_sequence.residue_type
+         _nef_sequence.residue_name
          
 	 # optional parameters
          _nef_sequence.linking
@@ -267,11 +267,11 @@ INSERT PULSE PROGRAM HERE
          # mandatory parameters
          _nef_covalent_links.chain_code_1
          _nef_covalent_links.sequence_code_1
-         _nef_covalent_links.residue_type_1
+         _nef_covalent_links.residue_name_1
          _nef_covalent_links.atom_name_1
          _nef_covalent_links.chain_code_2
          _nef_covalent_links.sequence_code_2
-         _nef_covalent_links.residue_type_2
+         _nef_covalent_links.residue_name_2
          _nef_covalent_links.atom_name_2
 
          # key: chain_code_1, sequence_code_1, atom_name_1, chain_code_2, sequence_code_2, atom_name_2
@@ -307,7 +307,7 @@ INSERT PULSE PROGRAM HERE
       loop_
          _nef_chemical_shift.chain_code
          _nef_chemical_shift.sequence_code
-         _nef_chemical_shift.residue_type
+         _nef_chemical_shift.residue_name
          _nef_chemical_shift.atom_name
          _nef_chemical_shift.value
          _nef_chemical_shift.value_uncertainty
@@ -409,11 +409,11 @@ save_nef_distance_restraint_list_L1
          _nef_distance_restraint.restraint_combination_id
          _nef_distance_restraint.chain_code_1
          _nef_distance_restraint.sequence_code_1
-         _nef_distance_restraint.residue_type_1
+         _nef_distance_restraint.residue_name_1
          _nef_distance_restraint.atom_name_1
          _nef_distance_restraint.chain_code_2
          _nef_distance_restraint.sequence_code_2
-         _nef_distance_restraint.residue_type_2
+         _nef_distance_restraint.residue_name_2
          _nef_distance_restraint.atom_name_2
          _nef_distance_restraint.weight
 
@@ -473,11 +473,11 @@ save_nef_distance_restraint_list_hbond1
          _nef_distance_restraint.restraint_combination_id
          _nef_distance_restraint.chain_code_1
          _nef_distance_restraint.sequence_code_1
-         _nef_distance_restraint.residue_type_1
+         _nef_distance_restraint.residue_name_1
          _nef_distance_restraint.atom_name_1
          _nef_distance_restraint.chain_code_2
          _nef_distance_restraint.sequence_code_2
-         _nef_distance_restraint.residue_type_2
+         _nef_distance_restraint.residue_name_2
          _nef_distance_restraint.atom_name_2
          _nef_distance_restraint.weight
 
@@ -545,19 +545,19 @@ save_nef_distance_restraint_list_hbond1
          _nef_dihedral_restraint.restraint_combination_id
          _nef_dihedral_restraint.chain_code_1
          _nef_dihedral_restraint.sequence_code_1
-         _nef_dihedral_restraint.residue_type_1
+         _nef_dihedral_restraint.residue_name_1
          _nef_dihedral_restraint.atom_name_1
          _nef_dihedral_restraint.chain_code_2
          _nef_dihedral_restraint.sequence_code_2
-         _nef_dihedral_restraint.residue_type_2
+         _nef_dihedral_restraint.residue_name_2
          _nef_dihedral_restraint.atom_name_2
          _nef_dihedral_restraint.chain_code_3
          _nef_dihedral_restraint.sequence_code_3
-         _nef_dihedral_restraint.residue_type_3
+         _nef_dihedral_restraint.residue_name_3
          _nef_dihedral_restraint.atom_name_3
          _nef_dihedral_restraint.chain_code_4
          _nef_dihedral_restraint.sequence_code_4
-         _nef_dihedral_restraint.residue_type_4
+         _nef_dihedral_restraint.residue_name_4
          _nef_dihedral_restraint.atom_name_4
          _nef_dihedral_restraint.weight
 
@@ -634,7 +634,7 @@ save_nef_distance_restraint_list_hbond1
       _nef_rdc_restraint_list.tensor_rhombicity     0.067
       _nef_rdc_restraint_list.tensor_chain_code     C
       _nef_rdc_restraint_list.tensor_sequence_code  900
-      _nef_rdc_restraint_list.tensor_residue_type   TNSR
+      _nef_rdc_restraint_list.tensor_residue_name   TNSR
 
       loop_
          # Mandatory parameters, except for restraint_combination_id
@@ -643,11 +643,11 @@ save_nef_distance_restraint_list_hbond1
          _nef_rdc_restraint.restraint_combination_id
          _nef_rdc_restraint.chain_code_1
          _nef_rdc_restraint.sequence_code_1
-         _nef_rdc_restraint.residue_type_1
+         _nef_rdc_restraint.residue_name_1
          _nef_rdc_restraint.atom_name_1
          _nef_rdc_restraint.chain_code_2
          _nef_rdc_restraint.sequence_code_2
-         _nef_rdc_restraint.residue_type_2
+         _nef_rdc_restraint.residue_name_2
          _nef_rdc_restraint.atom_name_2
          _nef_rdc_restraint.weight
 
@@ -787,15 +787,15 @@ save_nef_distance_restraint_list_hbond1
          _nef_peak.position_uncertainty_3
          _nef_peak.chain_code_1
          _nef_peak.sequence_code_1
-         _nef_peak.residue_type_1
+         _nef_peak.residue_name_1
          _nef_peak.atom_name_1
          _nef_peak.chain_code_2
          _nef_peak.sequence_code_2
-         _nef_peak.residue_type_2
+         _nef_peak.residue_name_2
          _nef_peak.atom_name_2
          _nef_peak.chain_code_3
          _nef_peak.sequence_code_3
-         _nef_peak.residue_type_3
+         _nef_peak.residue_name_3
          _nef_peak.atom_name_3
 
          # key: ordinal
@@ -920,63 +920,63 @@ save_nef_distance_restraint_list_hbond1
          _nef_peak.position_uncertainty_15
          _nef_peak.chain_code_1
          _nef_peak.sequence_code_1
-         _nef_peak.residue_type_1
+         _nef_peak.residue_name_1
          _nef_peak.atom_name_1
          _nef_peak.chain_code_2
          _nef_peak.sequence_code_2
-         _nef_peak.residue_type_2
+         _nef_peak.residue_name_2
          _nef_peak.atom_name_2
          _nef_peak.chain_code_3
          _nef_peak.sequence_code_3
-         _nef_peak.residue_type_3
+         _nef_peak.residue_name_3
          _nef_peak.atom_name_3
          _nef_peak.chain_code_4
          _nef_peak.sequence_code_4
-         _nef_peak.residue_type_4
+         _nef_peak.residue_name_4
          _nef_peak.atom_name_4
          _nef_peak.chain_code_5
          _nef_peak.sequence_code_5
-         _nef_peak.residue_type_5
+         _nef_peak.residue_name_5
          _nef_peak.atom_name_5
          _nef_peak.chain_code_6
          _nef_peak.sequence_code_6
-         _nef_peak.residue_type_6
+         _nef_peak.residue_name_6
          _nef_peak.atom_name_6
          _nef_peak.chain_code_7
          _nef_peak.sequence_code_7
-         _nef_peak.residue_type_7
+         _nef_peak.residue_name_7
          _nef_peak.atom_name_7
          _nef_peak.chain_code_8
          _nef_peak.sequence_code_8
-         _nef_peak.residue_type_8
+         _nef_peak.residue_name_8
          _nef_peak.atom_name_8
          _nef_peak.chain_code_9
          _nef_peak.sequence_code_9
-         _nef_peak.residue_type_9
+         _nef_peak.residue_name_9
          _nef_peak.atom_name_9
          _nef_peak.chain_code_10
          _nef_peak.sequence_code_10
-         _nef_peak.residue_type_10
+         _nef_peak.residue_name_10
          _nef_peak.atom_name_10
          _nef_peak.chain_code_11
          _nef_peak.sequence_code_11
-         _nef_peak.residue_type_11
+         _nef_peak.residue_name_11
          _nef_peak.atom_name_11
          _nef_peak.chain_code_12
          _nef_peak.sequence_code_12
-         _nef_peak.residue_type_12
+         _nef_peak.residue_name_12
          _nef_peak.atom_name_12
          _nef_peak.chain_code_13
          _nef_peak.sequence_code_13
-         _nef_peak.residue_type_13
+         _nef_peak.residue_name_13
          _nef_peak.atom_name_13
          _nef_peak.chain_code_14
          _nef_peak.sequence_code_14
-         _nef_peak.residue_type_14
+         _nef_peak.residue_name_14
          _nef_peak.atom_name_14
          _nef_peak.chain_code_15
          _nef_peak.sequence_code_15
-         _nef_peak.residue_type_15
+         _nef_peak.residue_name_15
          _nef_peak.atom_name_15
       
          # key: ordinal

--- a/specification/Commented_Example.nef
+++ b/specification/Commented_Example.nef
@@ -397,6 +397,14 @@ INSERT PULSE PROGRAM HERE
          226  O  16    DT  end         .                         .
          227  X   1   PHE  single      -HD1,-HD2,+ID1,+CLD2      .
          228  Y   1   ATP  single      .                         .
+         229  W   1   ASP  start       .                         .
+         231  W   2   CYS  middle      -HG                       .
+         232  W   3   ASP  middle      .                         .
+         233  W   4   CYS  middle      -HG                       .                    .
+         234  W   5   LYS  end         .                         .               .
+         235  W   6   CA   single      .                         .
+         236  W   7   CD   single      .                         .
+         
       stop_
 
 # The first column (ordinal) is a consecutive line number that does not persist  
@@ -469,6 +477,10 @@ INSERT PULSE PROGRAM HERE
          F 11 ASN N   G  5 ALA C
          X  1 PHE CD1 X  1 PHE ID1
          X  1 PHE CD2 X  1 PHE CLD2
+         W  1 ASP OD1 W  6 CA  CA
+         W  2 CYS SG  W  7 CD  CD
+         W  3 ASP OD1 W  6 CA  CA
+         W  4 CYS SG  W  7 CD  CD
       stop_
 
    save_
@@ -495,64 +507,104 @@ INSERT PULSE PROGRAM HERE
          _nef_chemical_shift.atom_name
          _nef_chemical_shift.value
          _nef_chemical_shift.value_uncertainty
+         _nef_chemical_shift.element
+         _nef_chemical_shift.isotope_number
       
          # key: chain_code, sequence_code, atom_name
 
-         @2    SS@12   .     CAi-1  48.2    0   
-         @2    SS@231  GLX?  CAi-1  48.2    0   
-         A     14      TRP   HB2    3.4     0   
-         A     14      TRP   HB3    3.2     0   
-         A     14      TRP   HE1    9.9     0   
-         A     14      TRP   NE1    135.6   0   
-         A     15      GLY   H      7.8     0   
-         A     15      GLY   N      106.5   0   
-         A     15      GLY   QA     3.42    0.02
-         A     17      VAL   H      8.12    0   
-         A     17      VAL   N      116.5   0   
-         A     17      VAL   CG%    22.1    0.3 
-         A     17      VAL   HG%    0.73    0.02
-         A     18      PHE   H      8.3     0   
-         A     18      PHE   HB2    2.87    0.02
-         A     18      PHE   HB3    2.42    0.02
-         A     18      PHE   N      119.5   0   
-         A     19      LEU   CA     172.2   0   
-         A     19      LEU   CB     58.5    0   
-         A     19      LEU   CDx    17.4    0.3 
-         A     19      LEU   CDy    18.7    0.3 
-         A     19      LEU   CG     32.3    0   
-         A     19      LEU   HBx    2.13    0.02
-         A     19      LEU   HBy    2.51    0.02
-         A     19      LEU   HDx%   0.87    0.02
-         A     19      LEU   HDy%   0.73    0.02
-         A     19      LEU   HN     7.2     0   
-         A     19      LEU   N      119.5   0   
-         A     20      CYS   HBx    3.2     0   
-         A     21      ALA   H      8.33    0.02
-         A     21      ALA   HA     4.17    0.02
-         A     21      ALA   HB%    1.34    0.02
-         A     21      ALA   N      123.4   0.4
-         A     22      THR   H      9.17    0.02
-         A     22      THR   HG2%   1.41    0.02
-         A     22      THR   HB     3.88    0.02
-         A     22      THR   N      123.4   0.4
-         A     23      LYS   CA     43.2    0.25
-         A     23      LYS   H      8.45    0.04
-         A     23      LYS   HA     4.27    0.02
-         A     23      LYS   N      123.45  0.4 
-         A     24      ASP   H      8.79    0   
-         A     24      ASP   N      124.1   0   
-         A     24      ASP   HBy    3.4     0   
-         A     24B     GLN   H      8.3     0   
-         A     24B     GLN   N      119.5   0   
-         A     24C     GLN   C      28.3    0   
-         A     24C     GLN   CA     22.2    0   
-         A     24C     GLN   CB     58.5    0   
-         A     24C     GLN   CG     32.3    0   
-         A     24D     TYR   H      8.3     0   
-         A     24D     TYR   N      119.5   0   
-         E     7       SER   HB2    3.52    0
-         Z     @5      GLX   H      9.1     0   
-         Z     @5      GLX   N      118.3   0   
+         @2    SS@12   .     CAi-1  48.2    0      .     .
+         @2    SS@231  GLX?  CAi-1  48.2    0      .     .
+         A     14      TRP   HB2    3.4     0      .     .
+         A     14      TRP   HB3    3.2     0      .     .
+         A     14      TRP   HE1    9.9     0      .     .
+         A     14      TRP   NE1    135.6   0      .     .
+         A     15      GLY   H      7.8     0      .     .
+         A     15      GLY   N      106.5   0      .     .
+         A     15      GLY   QA     3.42    0.02   .     .
+         A     17      VAL   H      8.12    0      .     .
+         A     17      VAL   N      116.5   0      .     .
+         A     17      VAL   CG%    22.1    0.3    .     .
+         A     17      VAL   HG%    0.73    0.02   .     .
+         A     18      PHE   H      8.3     0      .     .
+         A     18      PHE   HB2    2.87    0.02   .     .
+         A     18      PHE   HB3    2.42    0.02   .     .
+         A     18      PHE   N      119.5   0      .     .
+         A     19      LEU   CA     172.2   0      .     .
+         A     19      LEU   CB     58.5    0      .     .
+         A     19      LEU   CDx    17.4    0.3    .     .
+         A     19      LEU   CDy    18.7    0.3    .     .
+         A     19      LEU   CG     32.3    0      .     .
+         A     19      LEU   HBx    2.13    0.02   .     .
+         A     19      LEU   HBy    2.51    0.02   .     .
+         A     19      LEU   HDx%   0.87    0.02   .     .
+         A     19      LEU   HDy%   0.73    0.02   .     .
+         A     19      LEU   HN     7.2     0      .     .
+         A     19      LEU   N      119.5   0      .     .
+         A     20      CYS   HBx    3.2     0      .     .
+         A     21      ALA   H      8.33    0.02   .     .
+         A     21      ALA   HA     4.17    0.02   .     .
+         A     21      ALA   HB%    1.34    0.02   .     .
+         A     21      ALA   N      123.4   0.4    .     .
+         A     22      THR   H      9.17    0.02   .     .
+         A     22      THR   HG2%   1.41    0.02   .     .
+         A     22      THR   HB     3.88    0.02   .     .
+         A     22      THR   N      123.4   0.4    .     .
+         A     23      LYS   CA     43.2    0.25   .     .
+         A     23      LYS   H      8.45    0.04   .     .
+         A     23      LYS   HA     4.27    0.02   .     .
+         A     23      LYS   N      123.45  0.4    .     .
+         A     24      ASP   H      8.79    0      .     .
+         A     24      ASP   N      124.1   0      .     .
+         A     24      ASP   HBy    3.4     0      .     .
+         A     24B     GLN   H      8.3     0      .     .
+         A     24B     GLN   N      119.5   0      .     .
+         A     24C     GLN   C      28.3    0      .     .
+         A     24C     GLN   CA     22.2    0      .     .
+         A     24C     GLN   CB     58.5    0      .     .
+         A     24C     GLN   CG     32.3    0      .     .
+         A     24D     TYR   H      8.3     0      .     .
+         A     24D     TYR   N      119.5   0      .     .
+         E     7       SER   HB2    3.52    0      .     .
+         W     1       ASP   CA     44.1    0      .     .
+         W     1       ASP   CB     28.2    0      .     .
+         W     1       ASP   HA     4.1     0      .     .
+         W     1       ASP   HB2    2.3     0      .     .
+         W     1       ASP   HB3    2.4     0      .     .
+         W     2       CYS   CA     41.2    0      .     .
+         W     2       CYS   CB     27.3    0      .     .
+         W     2       CYS   H      7.3     0      .     .
+         W     2       CYS   HA     4.3     0      .     2
+         W     2       CYS   HB2    2.8     0      .     2
+         W     2       CYS   HB3    2.7     0      .     2
+         W     3       ASP   CA     44.1    0      .     .
+         W     3       ASP   CB     28.2    0      .     .
+         W     3       ASP   HA     4.1     0      .     .
+         W     3       ASP   H      9.1     0      .     .
+         W     3       ASP   HB2    2.3     0      .     .
+         W     3       ASP   HB3    2.4     0      .     .
+         W     4       CYS   CA     41.2    0      .     .
+         W     4       CYS   CB     27.3    0      .     .
+         W     4       CYS   H      7.9     0      .     .
+         W     4       CYS   HA     4.8     0      .     2
+         W     4       CYS   HB2    2.6     0      .     2
+         W     4       CYS   HB3    2.5     0      .     2
+         W     5       LYS   CA     41.2    0      .     .
+         W     5       LYS   CB     27.3    0      .     .
+         W     5       LYS   CG     23.2    0      .     .
+         W     5       LYS   CD     22.3    0      .     .
+         W     5       LYS   CE     26.3    0      .     .
+         W     5       LYS   H      8.4     0      .     .
+         W     5       LYS   HA     4.2     0      .     .
+         W     5       LYS   HB2    2.2     0      .     .
+         W     5       LYS   HB3    2.1     0      .     .
+         W     5       LYS   HG%    1.4     0      .     .
+         W     5       LYS   HD2    1.6     0      .     .
+         W     5       LYS   HD3    1.5     0      .     .
+         W     5       LYS   HE%    3.1     0      .     .
+         W     6       CA    CA     1.1     0      CA    .
+         W     7       CD    CD     -150.0  0      CD    111
+         Z     @5      GLX   H      9.1     0      .     .
+         Z     @5      GLX   N      118.3   0      .     .
       stop_
 
 # The atom_name by itself serves to distinguish between real atoms ('HA'),
@@ -564,10 +616,59 @@ INSERT PULSE PROGRAM HERE
 # der Waals radius.
 # Val 17 HG%/CG% show two methyl groups that overlap in both carbon and proton
 # dimensions.
+#
 # 19 LEU HDx% is the methyl bound to CDx (and not to CDy).
-# The last two shifts (with chain_code @2) are unassigned but observed resonances,
+#
+# Chain W illustrates the element and isotope specificatoin rules
+# It is supposed to represent a Ca,Cd peptide complex with 2H la
+         W     2       CYS   HA     4.3     0      .     2
+         W     2       CYS   HB2    2.8     0      .     2
+         W     2       CYS   HB3    2.7     0      .     2beled CYS in 50% H2O/D2O.
+# Residue 6 is Calcium, residue 7 is Cadmium.
+# Some shifts that can not be given in this list because of name clashes are in
+# shiftlist 2 instead.
+# Note that e.g. W  4  CYS H and HA must be referred to as H and HA throughout the file.
+# Whether the atoms in question are in fact 1H or 2H, e.g. in a peak assignment, must
+# be decided by reference to the experiment dimension nucleus.
+#
+# The last two shifts (with chain_code Z) are unassigned but observed resonances,
 
    save_
+
+   save_nef_chemical_shift_list_2
+
+      # All tags in this saveframe are mandatory, except for value_uncertainty.
+
+      _nef_chemical_shift_list.sf_category                nef_chemical_shift_list
+      _nef_chemical_shift_list.sf_framecode               nef_chemical_shift_list_1
+
+      loop_
+         _nef_chemical_shift.chain_code
+         _nef_chemical_shift.sequence_code
+         _nef_chemical_shift.residue_name
+         _nef_chemical_shift.atom_name
+         _nef_chemical_shift.value
+         _nef_chemical_shift.value_uncertainty
+         _nef_chemical_shift.element
+         _nef_chemical_shift.isotope_number
+      
+         # key: chain_code, sequence_code, atom_name
+         W     2       CYS   H      7.5     0      .     2
+         W     2       CYS   HA     4.3     0      .     2
+         W     2       CYS   HB2    2.8     0      .     2
+         W     2       CYS   HB3    2.7     0      .     2
+         W     3       ASP   H      9.2     0      .     2
+         W     4       CYS   H      7.8     0      .     2
+         W     4       CYS   HA     4.8     0      .     2
+         W     4       CYS   HB2    2.6     0      .     2
+         W     4       CYS   HB3    2.5     0      .     2
+         W     5       LYS   H      8.5     0      .     2
+         W     7       CD    CD     -151.0  0      CD    113
+      stop_
+
+# This list contains 2H and 13Cd chemicla shifts.
+# You cannot have two different isotopes of the same atom in the same shift list
+# So the alternative isotopes of backbone H and Cd must be given in a separate list
 
 
 #=======================================================================

--- a/specification/Commented_Example.nef
+++ b/specification/Commented_Example.nef
@@ -302,7 +302,6 @@ INSERT PULSE PROGRAM HERE
 
       _nef_chemical_shift_list.sf_category                nef_chemical_shift_list
       _nef_chemical_shift_list.sf_framecode               nef_chemical_shift_list_1
-      _nef_chemical_shift_list.atom_chemical_shift_units  ppm
 
       loop_
          _nef_chemical_shift.chain_code

--- a/specification/Commented_Example.nef
+++ b/specification/Commented_Example.nef
@@ -165,79 +165,246 @@ INSERT PULSE PROGRAM HERE
 	 # optional parameters
          _nef_sequence.linking
          _nef_sequence.residue_variant
+         _nef_sequence.cis_peptide
 
          # key: chain_code, sequence_code
 
-          1  A  13   ALA  start      .
-          2  A  14   TRP  middle     .
-          3  A  15   GLY  middle     .
-          4  A  16   ASN  middle     .
-          5  A  17   VAL  middle     .
-          6  A  18   PHE  middle     .
-          7  A  19   LEU  middle     .
-          8  A  20   CYS  middle     .
-          9  A  21   ALA  middle     .
-         10  A  22   THR  middle     .
-         11  A  23   LYS  middle     .
-         12  A  24   ASP  middle     .
-         13  A  24B  GLN  middle     .
-         14  A  24C  GLN  middle     .
-         15  A  24D  TYR  middle     .
-         16  A  25   HIS  end        .
-         17  B  17   CYS  single     .
-         18  C  1    GLY  cyclic     .
-         19  C  2    PRO  middle     cispeptide
-         20  C  3    ASP  middle     ASP_LL
-         21  C  4    GLY  middle     .
-         22  C  5    PRO  middle     .
-         23  C  6    ASP  cyclic     .
-         24  D -3    TNSR dummy      .
-         25  D -2    LL2  dummy      .
-         26  D -1    LL1  dummy      .
-         27  D  0    LL   dummy      .
-         28  D  1    ALA  .          .
-         29  D  2    CYS  .          .
-         30  D  3    GLY  .          .
-         31  D  4    CYS  .          .
-         32  D  5    VAL  .          .
-         33  D  6    CYS  .          .
-         34  D  7    PHE  .          .
-         35  D  8    CYS  .          .
-         36  D  9    ASN  .          .
-         37  E  1    ASN  break      .
-         38  E  2    THR  middle     .
-         39  E  3    ALA  middle     .
-         40  E  4    PRO  middle     .
-         41  E  5    ALA  middle     .
-         42  E  6    GLU  middle     .
-         43  E  7    SER  middle     .
-         44  E  8    GLN  middle     .
-         45  E  9    GLU  middle     GLU_LL
-         46  E  10   HIS  middle     HIS_LL_DHD1
-         47  E  11   HIS  middle     HIS_LL_DHE2
-         48  E  12   CYS  middle     CYS_LL
-         49  E  13   LYS  middle     LYS_LL_DHZ3
-         50  E  14   ARG  break      ARG_LL_DHH12
-         51  E  15   MOH  nonlinear  .
-         52  E  16   GLC  nonlinear  .
-         53  F   1   GLY  start      .
-         54  F   2   ILE  middle     .
-         55  F   3   SER  middle     .
-         56  F   4   THR  break      .
-         57  F  11   ASN  middle     .
-         58  F  12   SER  end        .
-         59  G   3   TYR  middle     .
-         60  G   4   GLY  middle     .
-         61  G   5   ALA  middle     .
-         62  Y   1   ATP  nonlinear  .
+           1  A  13   ALA  start      .            .
+           2  A  14   TRP  middle     .            .
+           3  A  15   GLY  middle     .            .
+           4  A  16   ASN  middle     .            .
+           5  A  17   VAL  middle     .            .
+           6  A  18   PHE  middle     .            .
+           7  A  19   LEU  middle     .            .
+           8  A  20   CYS  middle     -HD          .
+           9  A  21   ALA  middle     .            .
+          10  A  22   THR  middle     .            .
+          11  A  23   LYS  middle     .            .
+          12  A  24   ASP  middle     .            .
+          13  A  24B  GLN  middle     .            .
+          14  A  24C  GLN  middle     .            .
+          15  A  24D  TYR  middle     .            .
+          16  A  25   HIS  end        -HD1,+HE2    .
+          17  B  17   CYS  single     -HD          .
+          18  C  1    GLY  cyclic     .            .
+          19  C  2    PRO  middle     .            true
+          20  C  3    ASP  middle     .            .
+          21  C  4    GLY  middle     .            .
+          22  C  5    PRO  middle     .            .
+          23  C  6    ASP  cyclic     .            .
+          24  D -3    TNSR dummy      .            .
+          25  D -2    LL2  dummy      .            .
+          26  D -1    LL1  dummy      .            .
+          27  D  0    LL   dummy      .            .
+          28  D  1    ALA  .          .            .
+          29  D  2    CYS  .          -HD          .
+          30  D  3    GLY  .          .            .
+          31  D  4    CYS  .          -HD          .
+          32  D  5    VAL  .          .            .
+          33  D  6    CYS  .          -HD          .
+          34  D  7    PHE  .          .            .
+          35  D  8    CYS  .          -HD          .
+          36  D  9    ASN  .          .            .
+          37  E  1    ASN  break      .            .
+          38  E  2    THR  middle     -HG1,-OG1    .
+          39  E  3    ALA  middle     .            .
+          40  E  4    PRO  middle     .            .
+          41  E  5    ALA  middle     .            .
+          42  E  6    GLU  middle     -OE2         .
+          43  E  7    SER  middle     .            .
+          44  E  8    GLN  middle     .            .
+          45  E  9    GLU  middle     .            .
+          46  E  10   HIS  middle     .            .
+          47  E  11   HIS  middle     .            .
+          48  E  12   CYS  middle     .            .
+          49  E  13   LYS  middle     .            .
+          50  E  14   ARG  break      .            .
+          51  E  15   MOH  nonlinear  -HO          .
+          52  E  16   GLC  nonlinear  -HO1         .
+          53  F   1   GLY  start      .            .
+          54  F   2   ILE  middle     .            .
+          55  F   3   SER  middle     .            .
+          56  F   4   THR  break      .            .
+          57  F  11   ASN  middle     .            .
+          58  F  12   SER  end        .            .
+          59  G   3   TYR  middle     .            .
+          60  G   4   GLY  middle     .            .
+          61  G   5   ALA  middle     .            .
+          62  H   1   ALA  start      -H3          .
+          63  H   2   ALA  middle     .            .
+          64  H   3   ALA  end        .            .
+          65  H   4   ARG  start      -H3,-HH12    .
+          66  H   5   ARG  middle     -HH12        .
+          67  H   6   ARG  end        -HH12        .
+          68  H   7   ASN  start      -H3          .
+          69  H   8   ASN  middle     .            .
+          70  H   9   ASN  end        .            .
+          71  H  10   ASP  start      -H3          .
+          72  H  11   ASP  middle     .            .
+          73  H  12   ASP  end        .            .
+          74  H  13   CYS  start      -H3,-HG      .
+          75  H  14   CYS  middle     -HG          .
+          76  H  15   CYS  end        -HG          .
+          77  H  16   GLN  start      -H3          .
+          78  H  17   GLN  middle     .            .
+          79  H  18   GLN  end        .            .
+          80  H  19   GLU  start      -H3          .
+          81  H  20   GLU  middle     .            .
+          82  H  21   GLU  end        .            .
+          83  H  22   GLY  start      -H3          .
+          84  H  23   GLY  middle     .            .
+          85  H  24   GLY  end        .            .
+          86  H  25   HIS  start      -H3          .
+          87  H  26   HIS  middle     .            .
+          88  H  27   HIS  end        .            .
+          89  H  28   ILE  start      -H3          .
+          90  H  29   ILE  middle     .            .
+          91  H  30   ILE  end        .            .
+          92  H  31   LEU  start      -H3          .
+          93  H  32   LEU  middle     .            .
+          94  H  33   LEU  end        .            .
+          95  H  34   LYS  start      -H3,-HZ3     .
+          96  H  35   LYS  middle     -HZ3         .
+          97  H  36   LYS  end        -HZ3         .
+          98  H  37   MET  start      -H3          .
+          99  H  38   MET  middle     .            .
+         100  H  39   MET  end        .            .
+         101  H  40   PHE  start      -H3          .
+         102  H  41   PHE  middle     .            .
+         103  H  42   PHE  end        .            .
+         104  H  43   PRO  start      -H2,-H3,+H   .
+         105  H  44   PRO  middle     .            .
+         106  H  45   PRO  end        .            .
+         107  H  46   SER  start      -H3          .
+         108  H  47   SER  middle     .            .
+         109  H  48   SER  end        .            .
+         110  H  49   THR  start      -H3          .
+         111  H  50   THR  middle     .            .
+         112  H  51   THR  end        .            .
+         113  H  52   TRP  start      -H3          .
+         114  H  53   TRP  middle     .            .
+         115  H  54   TRP  end        .            .
+         116  H  55   TYR  start      -H3,-HH      .
+         117  H  56   TYR  middle     -HH          .
+         118  H  57   TYR  end        -HH          .
+         119  H  58   VAL  start      -H3          .
+         120  H  59   VAL  middle     .            .
+         121  H  60   VAL  end        .            .
+         122  L   1   ALA  start      .            .
+         123  L   2   ALA  middle     .            .
+         124  L   3   ALA  end        +HXT         .
+         125  L   4   ARG  start      .            .
+         126  L   5   ARG  middle     .            .
+         127  L   6   ARG  end        +HXT         .
+         128  L   7   ASN  start      .            .
+         129  L   8   ASN  middle     .            .
+         130  L   9   ASN  end        +HXT         .
+         131  L  10   ASP  start      +HD2         .
+         132  L  11   ASP  middle     +HD2         .
+         133  L  12   ASP  end        +HD2,+HXT    .
+         134  L  13   CYS  start      .            .
+         135  L  14   CYS  middle     .            .
+         136  L  15   CYS  end        +HXT         .
+         137  L  16   GLN  start      .            .
+         138  L  17   GLN  middle     .            .
+         139  L  18   GLN  end        +HXT         .
+         140  L  19   GLU  start      +HE2         .
+         141  L  20   GLU  middle     +HE2         .      .
+         142  L  21   GLU  end        +HE2,+HXT    .
+         143  L  22   GLY  start      .            .
+         144  L  23   GLY  middle     .            .
+         145  L  24   GLY  end        +HXT         .
+         146  L  25   HIS  start      +HE2         .
+         147  L  26   HIS  middle     +HE2         .
+         148  L  27   HIS  end        +HE2.+HXT    .
+         149  L  28   ILE  start      .            .
+         150  L  29   ILE  middle     .            .
+         151  L  30   ILE  end        +HX2         .
+         152  L  31   LEU  start      .           .
+         153  L  32   LEU  middle     .            .
+         154  L  33   LEU  end        +HXT         .
+         155  L  34   LYS  start      .            .
+         156  L  35   LYS  middle     .            .
+         157  L  36   LYS  end        +HXT         .
+         158  L  37   MET  start      '            .
+         159  L  38   MET  middle     .            .
+         160  L  39   MET  end        +HXT         .
+         161  L  40   PHE  start      .            .
+         162  L  41   PHE  middle     .            .
+         163  L  42   PHE  end        +HXT         .
+         164  L  43   PRO  start      .            .
+         165  L  44   PRO  middle     .            .
+         166  L  45   PRO  end        +HXT         .
+         167  L  46   SER  start      .            .
+         168  L  47   SER  middle     .            .
+         169  L  48   SER  end        +HXT         .
+         170  L  49   THR  start      .            .
+         171  L  50   THR  middle     .            .  .
+         172  L  51   THR  end        +HXT         .
+         173  L  52   TRP  start      .            .
+         174  L  53   TRP  middle     .            .
+         175  L  54   TRP  end        +HXT         .
+         176  L  55   TYR  start      .            .
+         177  L  56   TYR  middle     .            .
+         178  L  57   TYR  end        +HXT         .
+         179  L  58   VAL  start      .            .
+         180  L  59   VAL  middle     .            .
+         181  L  60   VAL  end        +HXT         .
+         182  M   1   ASP  start      -H3,+HD2     .
+         183  M   2   CYS  end        -HG,+HXT     .
+         184  M   3   ASP  start      .            .
+         185  M   4   CYS  end        .            .
+         186  M   5   GLU  start      -H3,+HE2     .
+         187  M   6   TYR  end        -HH,+HXT     .
+         188  M   7   GLU  start      .            .
+         189  M   8   TYR  end        .            .
+         190  M   9   HIS  start      -H3,+HE2     .
+         191  M  10   LYS  end        -HZ3,+HXT    .
+         192  M  11   HIS  start      .            .
+         193  M  12   LYS  end        .            .
+         194  M  13   ALA  start      .            .
+         195  M  14   ARG  end        .            .
+         196  M  15   ALA  start      .            .
+         197  M  16   ARG  end        -HH12,+HXT   .
+         198  M  17   HIS  start      -HD1,+HE2    .
+         199  M  18   HIS  middle     -HD1,+HE2    .
+         200  M  19   HIS  end        -HD1,+HE2    .
+         201  M  20   HIS  start      -H3,-HD1,+HE2   .
+         202  M  21   HIS  end        -HD1,+HE2,+HXT  .
+         203  N   1   CYS  single     .            .
+         204  N   2   CYS  single     -H3          .
+         205  N   3   CYS  single     +HXT         .
+         206  N   4   CYS  single     -H3,+HXT     .
+         207  N   5   CYS  single     -HG          .
+         208  N   6   CYS  single     -H3,-HG      .
+         209  N   7   CYS  single     -HG,+HXT     .
+         210  N   8   CYS  single     -H3,-HG,+HXT .
+         211  O   1     A  start       -HO5',+P,+OP1,+OP2.+OP3   .
+         212  O   2     A  end         .                         .
+         213  O   3     C  start       -HO5',+P,+OP1,+OP2.+OP3   .
+         214  O   4     C  end         .                         .
+         215  O   5     G  start       -HO5',+P,+OP1,+OP2.+OP3   .
+         216  O   6     G  end         .                         .
+         217  O   7     U  start       -HO5',+P,+OP1,+OP2.+OP3   .
+         218  O   8     U  end         .                         .
+         219  O   9    DA  start       -HO5',+P,+OP1,+OP2.+OP3   .
+         220  O  10    DA  end         .                         .
+         22 1 O  11    DC  start       -HO5',+P,+OP1,+OP2.+OP3   .
+         222  O  12    DC  end         .                         .
+         223  O  13    DG  start       -HO5',+P,+OP1,+OP2.+OP3   .
+         224  O  14    DG  end         .                         .
+         225  O  15    DT  start       -HO5',+P,+OP1,+OP2.+OP3   .
+         226  O  16    DT  end         .                         .
+         227  X   1   PHE  single      -HD1,-HD2,+ID1,+CLD2      .
+         228  Y   1   ATP  nonlinear  .
       stop_
 
 # The first column (ordinal) is a consecutive line number that does not persist  
 # when data are re-exported. It is there only to store the order that the lines
 # are givn inthe file (which is significant for specifying the sequence).
 #
-# Chain A is a linear Hexadecapeptide (13-25), disulfide linked to a free
-# cysteine (Chain B)
+# Chain A is a linear hexadecapeptide (13-25), disulfide linked to a free cysteine (chain B)
+# HIS 25 is protonated on NE2 rather than ND1 (and deprotonated on the C terminated carboxyl).
 #
 # Chain C is a cyclic hexapeptide, containing a cis-peptide bond at PRO 2.
 #
@@ -248,24 +415,35 @@ INSERT PULSE PROGRAM HERE
 # Note that there is NO sequential link between chains D and E, even though both have
 # dangling ends. Interchain links must always be given explictly in the _nef_covalent_links loop.
 #
-# Chain E has an amide bond between the between the backbone N of ASN 1 and the side chain carboxylate
+# Chain E has an amide bond between the backbone N of ASN 1 and the side chain carboxylate
 # of GLU 6, and a methyl ester cap.
-# It also has a glucose (with the same chain code) linked to THR 2
 #
 # Chains F and G represent a chimeric protein, where (part of) chain G has been
 # inserted into chain F while maintaining the original numbering. Each chain is given as a
-# single block of residues, with the 'break' linking to show the chain break, and the 
+# single block of residues, with the 'break' linking to show the chain gap, and the 
 # nef_covalent_links loop to show the additional sequential links.
 #
-# residue_variants default to the pH 7 forms, specifically protonated LYS, ARG, and N-terminus
-# and deprotonated ASP, GLU, and C-terminus. 'deprotonated' CYS is generally assumed to be the 
-# disulfide form (The RCSB variant codes do not distinguish between disulfide and deprotonated 
-# Note that each variant comes in three forms: 'middle' (contains '_LL'), 'end (contains '_LEO2'),
-# and 'start' (contains '_LSN3')
+# Chain H shows the high-pH form for all amino acids, with all removable protons removed.
+# Chain L shows the low-pH form for all amino acids, with all prrotonatable groups protonated.
+# Chain M shows intermediate-pH forms that differ from low and high pH forms, for all amino acids
+# Chains H, L, and M between them include all supported variants for linkings start, middle, and end.
 #
-# Chain E shows examples of how to specify the non-default forms supported by the NEF format.
+# Chain N shows the eight supported variants for free Cysteine, as an example.
+# Since few programs are expected to distinguish all variants, it is not considered necessary
+# to give a complete list for all amino acids.
 #
-# Chain Y is free ATP
+# Chain O shows the variants for nucleotides. The variant "-HO5',+P,+OP1,+OP2.+OP3" is the
+# phosphorylated 5' form, only relevant for 5' residues where the default is non-phosphorylated.
+# Except for phosphorylated, 5'-terminal residues, only the default variant is supported
+#
+# Chain X is free (1-iodo,3-chloro,phen-2-yl)-alanine (a non-standard residue).
+# Chain Y is free ATP. 
+#
+# Except for chains H, L, and parts of chain M, all residues are in a form appropriate for pH 7.
+#
+# Chains A, B, C, D, H, L, M, N, O, and Y should be readable by all programs,
+# whereas chains E, F, G, and X contain crosslinks or non-standard topologies.
+#
 
 # Covalent cross-links loop. Optional:
       loop_
@@ -289,6 +467,8 @@ INSERT PULSE PROGRAM HERE
          E 14 ARG C   E 15 MOH O
          F  4 THR C   G  3 TYR N
          F 11 ASN N   G  5 ALA C
+         X  1 PHE CD1 X  1 PHE ID1
+         X  1 PHE CD2 X  1 PHE CLD2
       stop_
 
    save_

--- a/specification/Commented_Example.nef
+++ b/specification/Commented_Example.nef
@@ -1025,4 +1025,41 @@ save_nef_distance_restraint_list_hbond1
 
 save_
 
+
+#=======================================================================
+# Section 10
+#
+# Optional: Program-specific raw_data saveframe
+#
+# Each program-specific prefix should include the 'programspecific_raw_data'
+# saveframe as a slot to add copies of raw input files.
+#
+# The preferred option remains to use structured program-specific tags
+# to store program-specific information, but this saveframe serves as a
+# quick way to add unstructured data or input files for comparison.
+#
+#=======================================================================
+
+save_xplor_raw_data_T1_T2_values_1
+    _xplor_raw_data.sf_category     xplor_raw_data
+    _xplor_raw_data.sf_framecode    xplor_raw_data_T1_T2_values_1
+
+    # ALl items below are optional:
+    _xplor_raw_data.file_name       input_file_name.extension
+
+    _xplor_raw_data.details
+; Optional item
+For comments.
+Any multiline text can be put here
+;
+
+    _xplor_raw_data.text
+;
+If the string starts with a new line (as in this case) it is skipped. This avoids issues with how many initial spaces to strip
+;
+save_
+
+
+
+
 # End of data_nef_my_nmr_project_1

--- a/specification/Commented_Example.nef
+++ b/specification/Commented_Example.nef
@@ -276,7 +276,7 @@ INSERT PULSE PROGRAM HERE
 
          # key: chain_code_1, sequence_code_1, atom_name_1, chain_code_2, sequence_code_2, atom_name_2
 
-         A 20 CYS SG B 17 CYS SG
+         A 20 CYS SG  B 17 CYS SG
          D  2 CYS SG  D  6 CYS SG
          D  4 CYS SG  D  8 CYS SG
          E  1 ASN N   E  6 GLU CD
@@ -322,6 +322,8 @@ INSERT PULSE PROGRAM HERE
          A     15      GLY   H      7.8     0   
          A     15      GLY   N      106.5   0   
          A     15      GLY   QA     3.42    0.02
+         A     17      VAL   H      8.12    0   
+         A     17      VAL   N      116.5   0   
          A     17      VAL   CG%    22.1    0.3 
          A     17      VAL   HG%    0.73    0.02
          A     18      PHE   H      8.3     0   
@@ -330,26 +332,31 @@ INSERT PULSE PROGRAM HERE
          A     18      PHE   N      119.5   0   
          A     19      LEU   CA     172.2   0   
          A     19      LEU   CB     58.5    0   
-         A     19      LEU   CD1    22.2    0   
-         A     19      LEU   CD2    58.5    0   
-         A     19      LEU   CDX    17.4    0.3 
-         A     19      LEU   CDY    18.7    0.3 
+         A     19      LEU   CDx    17.4    0.3 
+         A     19      LEU   CDy    18.7    0.3 
          A     19      LEU   CG     32.3    0   
-         A     19      LEU   HBX    2.13    0.02
-         A     19      LEU   HBY    2.51    0.02
-         A     19      LEU   HDX%   0.87    0.02
-         A     19      LEU   HDY%   0.73    0.02
+         A     19      LEU   HBx    2.13    0.02
+         A     19      LEU   HBy    2.51    0.02
+         A     19      LEU   HDx%   0.87    0.02
+         A     19      LEU   HDy%   0.73    0.02
          A     19      LEU   HN     7.2     0   
          A     19      LEU   N      119.5   0   
-         A     20      CYS   HBX    3.2     0   
+         A     20      CYS   HBx    3.2     0   
          A     21      ALA   H      8.33    0.02
          A     21      ALA   HA     4.17    0.02
          A     21      ALA   HB%    1.34    0.02
+         A     21      ALA   N      123.4   0.4
+         A     22      THR   H      9.17    0.02
+         A     22      THR   HG2%   1.41    0.02
+         A     22      THR   HB     3.88    0.02
+         A     22      THR   N      123.4   0.4
          A     23      LYS   CA     43.2    0.25
          A     23      LYS   H      8.45    0.04
          A     23      LYS   HA     4.27    0.02
          A     23      LYS   N      123.45  0.4 
-         A     24      ASP   HBY    3.4     0   
+         A     24      ASP   H      8.79    0   
+         A     24      ASP   N      124.1   0   
+         A     24      ASP   HBy    3.4     0   
          A     24B     GLN   H      8.3     0   
          A     24B     GLN   N      119.5   0   
          A     24C     GLN   C      28.3    0   
@@ -358,20 +365,21 @@ INSERT PULSE PROGRAM HERE
          A     24C     GLN   CG     32.3    0   
          A     24D     TYR   H      8.3     0   
          A     24D     TYR   N      119.5   0   
+         E     7       SER   HB2    3.52    0
          Z     @5      GLX   H      9.1     0   
          Z     @5      GLX   N      118.3   0   
       stop_
 
 # The atom_name by itself serves to distinguish between real atoms ('HA'),
 #  pseudoatoms ('QA'), sets of atoms ('HB%'), sterospecifically assigned atoms
-# ('HB2'), and non-stereospecifically assigned atoms ('HBX').
+# ('HB2'), and non-stereospecifically assigned atoms ('HBx').
 # In the example, Phe 18 HB2/HB3 are stereospecifically assigned, while Leu 19
 # is not.
 # Gly 15 QA is a pseudoatom, i.e. an atom at the HA2/HA3 centroid with zero van
 # der Waals radius.
 # Val 17 HG%/CG% show two methyl groups that overlap in both carbon and proton
 # dimensions.
-# 19 LEU HDX% is the methyl bound to CDX (and not to CDY).
+# 19 LEU HDx% is the methyl bound to CDx (and not to CDy).
 # The last two shifts (with chain_code @2) are unassigned but observed resonances,
 
    save_
@@ -432,9 +440,9 @@ save_nef_distance_restraint_list_L1
          2  1  .  A  17  VAL  H    A  22  THR  HG2%  1  3.7  0.4  2    2.5  4.2  4.7
          3  1  .  A  18  LEU  H    A  21  ALA  HB%   1  3.7  0.4  2    2.5  4.2  4.7
          4  1  .  A  18  LEU  H    A  22  THR  HG2%  1  3.7  0.4  2    2.5  4.2  4.7
-         5  5  .  A  18  PHE  HB2  A  24  ASP  HBX   1  2.8  0.4  1.5  2    3.2  3.7
-         6  8  .  A  18  PHE  HB2  A  24  ASP  HBY   1  4.4  0.4  3.6  4.1  5.2  5.7
-         7  8  .  A  24  ASP  HBY  E   7  SER  HB2   1  4.4  0.4  3.6  4.1  5.2  5.7
+         5  5  .  A  18  PHE  HB2  A  24  ASP  HBy   1  2.8  0.4  1.5  2    3.2  3.7
+         6  8  .  A  18  PHE  HB2  A  24  ASP  HBy  1  4.4  0.4  3.6  4.1  5.2  5.7
+         7  8  .  A  24  ASP  HBy  E   7  SER  HB2   1  4.4  0.4  3.6  4.1  5.2  5.7
       stop_
 
       # The first column (index_id) is a consecutive line number that does not persist  
@@ -492,10 +500,10 @@ save_nef_distance_restraint_list_hbond1
       
          # key: index_id
 
-         1  1  .  A  15  VAL  H    A  24B  THR  O     1  1.8    .  .  1.4    2.7  .
-         2  2  .  A  15  VAL  N    A  24B  THR  O     1  2.8    .  .  2.4    3.7  .
-         3  3  1  A  13  THR  O    A  16   VAL  H     1  1.8    .  .  1.4    2.7  .
-         4  3  1  A  13  THR  O    A  16   VAL  N     1  2.8    .  .  2.4    3.7  .
+         1  1  .  A  15  GLY  H    A  24B  GLN  O     1  1.8    .  .  1.4    2.7  .
+         2  2  .  A  15  GLY  N    A  24B  GLN  O     1  2.8    .  .  2.4    3.7  .
+         3  3  1  A  13  THR  O    A  19   LEU  H     1  1.8    .  .  1.4    2.7  .
+         4  3  1  A  13  THR  O    A  19   LEU  N     1  2.8    .  .  2.4    3.7  .
          5  4  2  A  17  VAL  H    A  22   THR  O     1  1.8    .  .  1.4    2.7  .
          6  4  2  A  17  VAL  N    A  22   THR  O     1  2.8    .  .  2.4    3.7  .
          7  4  3  A  17  VAL  H    A  24   ASP  O     1  1.8    .  .  1.4    2.7  .
@@ -582,7 +590,8 @@ save_nef_distance_restraint_list_hbond1
          7   4  2  A  16  ASN  N   A  16  ASN  CA  A  16  ASN  C   A  17   VAL  N    1  -50  5  .  -60  -40  .  PSI
          8   4  3  A  15  GLY  C   A  16  ASN  N   A  16  ASN  CA  A  16   ASN  C    1  -80  5  .  -90  -70  .  PHI
          9   4  3  A  16  ASN  N   A  16  ASN  CA  A  16  ASN  C   A  17   VAL  N    1  -80  5  .  -90  -70  .  PSI
-         10  5  .  A  19  LEU  CA  A  19  LEU  CB  A  19  LEU  CG  A  19   LEU  CDX  1  -80  5  .  -90  -70  .  .  
+         10  5  .  A  19  LEU  CA  A  19  LEU  CB  A  19  LEU  CG  A  19   LEU  CDx  1  -80  5  .  -90  -70  .  .  
+         11  6  .  A  21  LYS  CA  A  21  LYS  CB  A  21  LYS  CG  A  21   LYS  CD   1  -80  5  .  -90  -70  .  CHI2
       stop_
 
       # - Restraint 1 is an ambiguous psi restraint. The atoms are the same,
@@ -800,14 +809,14 @@ save_nef_distance_restraint_list_hbond1
          # key: index_id
 
          1   1  73000000  5100000   33000000  1100000   3.2  0.05  119.5  0.5  8.3  0.03  A  14  TRP  HB3  A  18    PHE  N    A  18    PHE  H  
-         2   1  73000000  5100000   33000000  1100000   3.2  0.05  119.5  0.5  8.3  0.03  A  19  LEU  HBY  A  24B   GLN  N    A  24B   GLN  H  
-         3   1  73000000  5100000   33000000  1100000   3.2  0.05  119.5  0.5  8.3  0.03  A  19  LEU  HBY  A  24D   TYR  N    A  24D   TYR  H  
-         4   1  73000000  5100000   33000000  1100000   3.2  0.05  119.5  0.5  8.3  0.03  A  20  CYS  HBX  A  24B   GLN  N    A  24B   GLN  H  
-         5   1  73000000  5100000   33000000  1100000   3.2  0.05  119.5  0.5  8.3  0.03  A  20  CYS  HBX  A  24D   TYR  N    A  24D   TYR  H  
+         2   1  73000000  5100000   33000000  1100000   3.2  0.05  119.5  0.5  8.3  0.03  A  19  LEU  HBy  A  24B   GLN  N    A  24B   GLN  H  
+         3   1  73000000  5100000   33000000  1100000   3.2  0.05  119.5  0.5  8.3  0.03  A  19  LEU  HBy  A  24D   TYR  N    A  24D   TYR  H  
+         4   1  73000000  5100000   33000000  1100000   3.2  0.05  119.5  0.5  8.3  0.03  A  20  CYS  HBx  A  24B   GLN  N    A  24B   GLN  H  
+         5   1  73000000  5100000   33000000  1100000   3.2  0.05  119.5  0.5  8.3  0.03  A  20  CYS  HBx  A  24D   TYR  N    A  24D   TYR  H  
          6   3  54000000  7300000   34000000  5300000   4.4  0.05  106.5  0.5  7.8  0.03  .  .   .    .    A  15    GLY  N    A  15    GLY  H  
          7   4  88000000  13000000  48000000  3300000   3.2  0.05  135.6  0.5  9.9  0.03  A  14  TRP  HB3  A  14    TRP  NE1  A  14    TRP  HE1
          8   5  88000000  13000000  58000000  23000000  3.4  0.05  135.6  0.5  9.9  0.03  A  14  TRP  HB2  A  14    TRP  NE1  A  14    TRP  HE1
-         9   5  88000000  13000000  58000000  23000000  3.4  0.05  135.6  0.5  9.9  0.03  A  24  ASP  HBY  A  14    TRP  NE1  A  14    TRP  HE1
+         9   5  88000000  13000000  58000000  23000000  3.4  0.05  135.6  0.5  9.9  0.03  A  24  ASP  HBy  A  14    TRP  NE1  A  14    TRP  HE1
          10  7  59000000  7100000   29000000  6100000   1.7  0.05  118.3  0.5  9.1  0.03  .  .   .    .    Z  @5    GLX  N    Z  @5    GLX  H  
       stop_
 
@@ -980,7 +989,7 @@ save_nef_distance_restraint_list_hbond1
       
          # key: index_id
 
-         1  1  73000000  5100000  33000000  1100000  7.2  0.05  119.5  0.4  28.3  0.3  172.2  0.5  58.5  0.4  32.3  0.4  22.2  0.5  58.5  0.4  32.3  0.4  22.2  0.5  58.5  0.4  32.3  0.4  22.2  0.5  58.5  0.4  32.3  0.4  A  19  LEU  HN  A  19  LEU  N  A  24C   GLN  C  A  19  LEU  CA  A  19  LEU  CB  A  19  LEU  CG  A  19  LEU  CD1  A  19  LEU  CD2  A  19  LEU  CG  A  19  LEU  CA  A  19  LEU  CB  A  19  LEU  CG  A  24C   GLN  CA  A  24C   GLN  CB  A  24C   GLN  CG
+         1  1  73000000  5100000  33000000  1100000  7.2  0.05  119.5  0.4  28.3  0.3  172.2  0.5  58.5  0.4  32.3  0.4  22.2  0.5  58.5  0.4  32.3  0.4  22.2  0.5  58.5  0.4  32.3  0.4  22.2  0.5  58.5  0.4  32.3  0.4  A  19  LEU  HN  A  19  LEU  N  A  24C   GLN  C  A  19  LEU  CA  A  19  LEU  CB  A  19  LEU  CG  A  19  LEU  CDx  A  19  LEU  CDy  A  19  LEU  CG  A  19  LEU  CA  A  19  LEU  CB  A  19  LEU  CG  A  24C   GLN  CA  A  24C   GLN  CB  A  24C   GLN  CG
       stop_
    save_
 

--- a/specification/Commented_Example.nef
+++ b/specification/Commented_Example.nef
@@ -205,7 +205,7 @@ INSERT PULSE PROGRAM HERE
           34  D  7    PHE  .          .            .
           35  D  8    CYS  .          -HD          .
           36  D  9    ASN  .          .            .
-          37  E  1    ASN  break      .            .
+          37  E  1    ASN  middle     .            .
           38  E  2    THR  middle     -HG1,-OG1    .
           39  E  3    ALA  middle     .            .
           40  E  4    PRO  middle     .            .
@@ -218,9 +218,9 @@ INSERT PULSE PROGRAM HERE
           47  E  11   HIS  middle     .            .
           48  E  12   CYS  middle     .            .
           49  E  13   LYS  middle     .            .
-          50  E  14   ARG  break      .            .
-          51  E  15   MOH  nonlinear  -HO          .
-          52  E  16   GLC  nonlinear  -HO1         .
+          50  E  14   ARG  middle     .            .
+          51  E  15   MOH  single     -HO          .
+          52  E  16   GLC  single     -HO1         .
           53  F   1   GLY  start      .            .
           54  F   2   ILE  middle     .            .
           55  F   3   SER  middle     .            .
@@ -396,7 +396,7 @@ INSERT PULSE PROGRAM HERE
          225  O  15    DT  start       -HO5',+P,+OP1,+OP2.+OP3   .
          226  O  16    DT  end         .                         .
          227  X   1   PHE  single      -HD1,-HD2,+ID1,+CLD2      .
-         228  Y   1   ATP  nonlinear  .
+         228  Y   1   ATP  single      .                         .
       stop_
 
 # The first column (ordinal) is a consecutive line number that does not persist  

--- a/specification/Commented_Example.nef
+++ b/specification/Commented_Example.nef
@@ -157,6 +157,7 @@ INSERT PULSE PROGRAM HERE
       # Mandatory:
       loop_
 	 # mandatory parameters
+         _nef_sequence.ordinal
          _nef_sequence.chain_code
          _nef_sequence.sequence_code
          _nef_sequence.residue_name
@@ -167,70 +168,74 @@ INSERT PULSE PROGRAM HERE
 
          # key: chain_code, sequence_code
 
-         A  13   ALA  start      .
-         A  14   TRP  middle     .
-         A  15   GLY  middle     .
-         A  16   ASN  middle     .
-         A  17   VAL  middle     .
-         A  18   PHE  middle     .
-         A  19   LEU  middle     .
-         A  20   CYS  middle     .
-         A  21   ALA  middle     .
-         A  22   THR  middle     .
-         A  23   LYS  middle     .
-         A  24   ASP  middle     .
-         A  24B  GLN  middle     .
-         A  24C  GLN  middle     .
-         A  24D  TYR  middle     .
-         A  25   HIS  end        .
-         B  17   CYS  single     .
-         C  1    GLY  cyclic     .
-         C  2    PRO  middle     cispeptide
-         C  3    ASP  middle     ASP_LL
-         C  4    GLY  middle     .
-         C  5    PRO  middle     .
-         C  6    ASP  cyclic     .
-         D -3    TNSR dummy      .
-         D -2    LL2  dummy      .
-         D -1    LL1  dummy      .
-         D  0    LL   dummy      .
-         D  1    ALA  .          .
-         D  2    CYS  .          .
-         D  3    GLY  .          .
-         D  4    CYS  .          .
-         D  5    VAL  .          .
-         D  6    CYS  .          .
-         D  7    PHE  .          .
-         D  8    CYS  .          .
-         D  9    ASN  .          .
-         E  1    ASN  break      .
-         E  2    THR  middle     .
-         E  3    ALA  middle     .
-         E  4    PRO  middle     .
-         E  5    ALA  middle     .
-         E  6    GLU  middle     .
-         E  7    SER  middle     .
-         E  8    GLN  middle     .
-         E  9    GLU  middle     GLU_LL
-         E  10   HIS  middle     HIS_LL_DHD1
-         E  11   HIS  middle     HIS_LL_DHE2
-         E  12   CYS  middle     CYS_LL
-         E  13   LYS  middle     LYS_LL_DHZ3
-         E  14   ARG  break      ARG_LL_DHH12
-         E  15   MOH  nonlinear  .
-         E  16   GLC  nonlinear  .
-         F   1   GLY  start      .
-         F   2   ILE  middle     .
-         F   3   SER  middle     .
-         F   4   THR  break      .
-         F  11   ASN  middle     .
-         F  12   SER  end        .
-         G   3   TYR  middle     .
-         G   4   GLY  middle     .
-         G   5   ALA  middle     .
-         Y   1   ATP  nonlinear  .
+          1  A  13   ALA  start      .
+          2  A  14   TRP  middle     .
+          3  A  15   GLY  middle     .
+          4  A  16   ASN  middle     .
+          5  A  17   VAL  middle     .
+          6  A  18   PHE  middle     .
+          7  A  19   LEU  middle     .
+          8  A  20   CYS  middle     .
+          9  A  21   ALA  middle     .
+         10  A  22   THR  middle     .
+         11  A  23   LYS  middle     .
+         12  A  24   ASP  middle     .
+         13  A  24B  GLN  middle     .
+         14  A  24C  GLN  middle     .
+         15  A  24D  TYR  middle     .
+         16  A  25   HIS  end        .
+         17  B  17   CYS  single     .
+         18  C  1    GLY  cyclic     .
+         19  C  2    PRO  middle     cispeptide
+         20  C  3    ASP  middle     ASP_LL
+         21  C  4    GLY  middle     .
+         22  C  5    PRO  middle     .
+         23  C  6    ASP  cyclic     .
+         24  D -3    TNSR dummy      .
+         25  D -2    LL2  dummy      .
+         26  D -1    LL1  dummy      .
+         27  D  0    LL   dummy      .
+         28  D  1    ALA  .          .
+         29  D  2    CYS  .          .
+         30  D  3    GLY  .          .
+         31  D  4    CYS  .          .
+         32  D  5    VAL  .          .
+         33  D  6    CYS  .          .
+         34  D  7    PHE  .          .
+         35  D  8    CYS  .          .
+         36  D  9    ASN  .          .
+         37  E  1    ASN  break      .
+         38  E  2    THR  middle     .
+         39  E  3    ALA  middle     .
+         40  E  4    PRO  middle     .
+         41  E  5    ALA  middle     .
+         42  E  6    GLU  middle     .
+         43  E  7    SER  middle     .
+         44  E  8    GLN  middle     .
+         45  E  9    GLU  middle     GLU_LL
+         46  E  10   HIS  middle     HIS_LL_DHD1
+         47  E  11   HIS  middle     HIS_LL_DHE2
+         48  E  12   CYS  middle     CYS_LL
+         49  E  13   LYS  middle     LYS_LL_DHZ3
+         50  E  14   ARG  break      ARG_LL_DHH12
+         51  E  15   MOH  nonlinear  .
+         52  E  16   GLC  nonlinear  .
+         53  F   1   GLY  start      .
+         54  F   2   ILE  middle     .
+         55  F   3   SER  middle     .
+         56  F   4   THR  break      .
+         57  F  11   ASN  middle     .
+         58  F  12   SER  end        .
+         59  G   3   TYR  middle     .
+         60  G   4   GLY  middle     .
+         61  G   5   ALA  middle     .
+         62  Y   1   ATP  nonlinear  .
       stop_
 
+# The first column (ordinal) is a consecutive line number that does not persist  
+# when data are re-exported. It is there only to store the order that the lines
+# are givn inthe file (which is significant for specifying the sequence).
+#
 # Chain A is a linear Hexadecapeptide (13-25), disulfide linked to a free
 # cysteine (Chain B)
 #

--- a/specification/Overview.md
+++ b/specification/Overview.md
@@ -692,3 +692,18 @@ expressions for Threonine and applying the standard regular expression rules.
     corresponds to multiple lines in the relevant loops). Each peak can be
     linked to multiple restraints, and vice versa. Links to different types of
     restraint all share a single table.
+    
+
+  * Regarding Section 10. Optional: **Program-specific raw_data saveframe**
+  
+    1. Each program-specific namespace should include the '_programspecific_raw_data'
+    saveframe (e.g. '_cyana_raw_data', '_csrosetta_raw_data' etc. as a slot to add 
+    copies of raw input files. The preferred option remains to use structured 
+    program-specific tags to store program-specific information, but this 
+    saveframe serves as a quick way to add unstructured data or copies of input 
+    files for comparison.
+    
+    NB, being program-specific this saveframe is not specified in the mmcIf_nef.dic
+    specification file, but only shown as an example in the Commented_Example.nef
+    file. Suggestions are welcome as to how such a saveframe should be put into the
+    general nef specification.

--- a/specification/Overview.md
+++ b/specification/Overview.md
@@ -11,9 +11,10 @@ organised by data category (saveframe).
 
   1. Residue and Atom names
 
-    Residues are identified by three strings ('chain_code', 'sequence_code',
-    'residue_type') that always are used together. Atoms are identified by a
-    residue identifier plus the atom name as a fourth string.
+    Residues are identified by three strings ('chain_code' (e.g. 'A'), 'sequence_code' 
+    (e.g. ('127'), 'residue_name' (e.g. 'ALA')) that always are used together. 
+    Atoms are identified by a residue identifier plus the atom name (e.g. 'HA')
+    as a fourth string.
 
     1. The identifying strings are case sensitive, and all identifiers
     (including casing) must be consistent throughout a file. Atom names and
@@ -42,12 +43,12 @@ organised by data category (saveframe).
     a small subset of the RCSB residue variant codes (see below). It remains an
     outstanding issue whether this should be changed or expanded.
 
-    5. 'residue_type' must be specified as the basic type in all cases (e.g. use
+    5. 'residue_name' must be specified as the basic type in all cases (e.g. use
     HIS regardless of protonation state).
 
     6. A residue is uniquely identified by the 'chain_code' and 'sequence_code',
-    so that the same 'residue_type' string must be used consistently throughout
-    the file. Strictly speaking this makes the 'residue_type' string redundant,
+    so that the same 'residue_name' string must be used consistently throughout
+    the file. Strictly speaking this makes the 'residue_name' string redundant,
     but it is used in identifiers to avoid ambiguity and to serve as a
     cross-check.
 
@@ -129,7 +130,7 @@ organised by data category (saveframe).
 
     13. Selection expressions. For the time being wildcards are allowed only
     for atom names. It would be possible to extend their use to 'chain_code',
-    'sequence_code' and 'residue_type' at a later date, if there is a use case
+    'sequence_code' and 'residue_name' at a later date, if there is a use case
     for this. More complex selection expressions, such as residue ranges, are
     surely too complicated for this kind of format. Note that these can be
     expressed as ambiguous peak assignments or restraints. For the specific
@@ -383,7 +384,7 @@ expressions for Threonine and applying the standard regular expression rules.
 
     4. The '_sequence' loop is a compromise between a full, complex topology
     description and simply assuming linear polymers - see the example files,
-    section 3. The '_nef_sequence.residue_type' is always the
+    section 3. The '_nef_sequence.residue_name' is always the
     canonical name (e.g. 'HIS' regardless of protonation state or chain
     position).The '_nef_sequence.linking' column shows linear connection
     information.
@@ -448,7 +449,7 @@ expressions for Threonine and applying the standard regular expression rules.
      'LL' (middle of chain), 'LSN3' (N-terminal, protonated),
      'LEO2' (C-terminal, deprotonated), and 'LEO2H' (C-terminal, protonated).
 
-| Residue_type | dyana_type | protonation_code | example | comment |
+| residue_name | dyana_type | protonation_code | example | comment |
 |-----|:-----|:-------|-----|-----|
 | ARG | ARG  | DHH12  | ARG_LL_DHH12 | side chain deprotonated |
 | ASP | ASP  | *None* | ASP_LL | side chain protonated |
@@ -599,8 +600,8 @@ expressions for Threonine and applying the standard regular expression rules.
   * Regarding Section 7. Optional: **RDC restraint lists(s)**
 
     1. The orientation tensor is indicated by giving the 'chain_code',
-    'sequence_code', and 'residue_type' for the residue used to give the
-    orientation tensor in coordinate files. The 'residue_type' should be TNSR.
+    'sequence_code', and 'residue_name' for the residue used to give the
+    orientation tensor in coordinate files. The 'residue_name' should be TNSR.
     Tensor values are given as magnitude and rhombicity.
 
     2. The RDC restraint list can also be used to give non-reduced dipolar

--- a/specification/Overview.md
+++ b/specification/Overview.md
@@ -144,7 +144,7 @@ organised by data category (saveframe).
       used where necessary, mainly for 'H\*', 'C\*', '\*',  ... (all protons, all
       carbons,  all atoms, etc.), or for atom names that do not use digits for
       distinguishing stereochemistry (e.g. DNA/RNA H5' and H5'', where the
-      two-atom is designated H5'\*).
+      two-atom set is designated H5'\*).
 
     11. IUPAC pseudoatom names (ALA MB, SER QB, etc.) are NOT expanded into
     sets of atoms. They are reserved for the
@@ -166,7 +166,8 @@ organised by data category (saveframe).
       not necessary to give the same chemical shift twice. If e.g. a Ser HB%
       shift is given, the HBx, HBy, HB2, and HB3 are known to be the same.
       Similarly HB% or QB can be used without any obligation to give their
-      shift explicitly. Indeed you can have restraints to atoms that have never
+      shift explicitly, also if the atoms involved have different shifts. 
+      Indeed you can have restraints to atoms that have never
       be measured (like oxygens in hydrogen bond restraints) and these need not
       appear in restraint lists.
       In cases where two protons are indistinguishable by NMR it
@@ -378,8 +379,10 @@ Wildcard atom sets for N-terminal Threonine
 
 These expressions are for illustrative purposes only. They comprise the simplest
 possible expressions that give a meaningful set of atoms, as well as expressions
-for HA, HB, and HG1 that would not be meaningful in context, to illustrate the
+for HA, HB, and HG1, that would not be meaningful in context, to illustrate the
 system. Only the expressions H%, HG2%, and H\* would appear in normal use.
+See the specification/Residue_Variants.txt file for supported standard wildcard
+expressions.
 
 ### Data Types
 
@@ -497,48 +500,17 @@ system. Only the expressions H%, HG2%, and H\* would appear in normal use.
       ... -middle-end'. Only standard linear polymer links can be inferred from
       the sequence; other links are given in the 'covalent_links' loop below.
 
-      By default residue variants are assumed to be the pH 7 forms,
-      specifically fully protonated HIS, LYS, ARG and N-terminus,
-      deprotonated ASP, GLU, and C-terminus, and deprotonated or disulfide
-      linked CYS (the PDB residue variants codes makes no distinction between
-      the two cases). The default types correspond to the DYANA types 'ARG+',
-      'ASP-', 'CYSS', 'GLU-', HIST+', and 'LYS+'. The optional
-      'residue_variant' column can be used for specifying protonation states
-      when these are known and different from the default.
-
-      The RCSB system requires a short introduction. The names are in three
-      parts, connected by underscores:
-        - first the three-letter residue code.
-        - second a backbone configuration marker, with the relevant values:
-          - 'LL' (L-amino acid, in middle of chain)
-          - 'LSN3' (L-amino acid, at start of chain, N-terminal protonated)
-          - 'LEO2' (L-amino acid, at end of chain, deprotonated C terminus)
-          - 'LEO2H' (L-amino acid, at end of chain, protonated C terminus)
-        - third a string showing which proton has been removed from the fully
-          protonated form.
-
-      See table below for supported variant codes.
+      By default residue variants are assumed to be the pH 7 forms. Programs
+      are required to support (in the sense of being able to read and 
+      sensibly interpret) the standard 20 amino acids, 4 DNA and 4 RNA 
+      nucleotides, toghether with their standard variants and wildcard atoms. 
+      These are all defined in the specification/Residue_Variants.txt file.
 
     5. The ordinal column is a line number with consecutive integers starting
     at 1. It is not preserved on import and re-export. The purpose it to
     preserve the order of the lines (which is significant for specifying the
     sequence) for implementations like (deposition) databases that do not use
     ordered containers for the data.
-
-  **Supported residue variant codes**:
-  Note that each comes in four different versions, all for L-amino acids:
-   'LL' (middle of chain), 'LSN3' (N-terminal, protonated),
-   'LEO2' (C-terminal, deprotonated), and 'LEO2H' (C-terminal, protonated).
-
-| residue_name | dyana_type | protonation_code | example | comment |
-|-----|:-----|:-------|-----|-----|
-| ARG | ARG  | DHH12  | ARG_LL_DHH12 | side chain deprotonated |
-| ASP | ASP  | *None* | ASP_LL | side chain protonated |
-| CYS | CYS  | *None* | CYS_LL | side chain protonated |
-| GLU | GLU  | *None* | GLU_LL | side chain protonated |
-| HIS | HIS  | DHE2   | HIS_LL_DHE2 | side chain neutral, proton on ND1 |
-| HIS | HIST | DHD1   | HIS_LL_DHD1 | side chain neutral, proton on NE2 |
-| LYS | LYS  | DHZ3   | LYS_LL_DHZ3 | side chain deprotonated |
 
 
   * Regarding Section 5. Optional: **Distance restraint lists(s)**
@@ -593,8 +565,11 @@ system. Only the expressions H%, HG2%, and H\* would appear in normal use.
 
       For another  discussion of more complex restraint logic, using the
       'restraint_combination_id', see section 6.
+    
+    8. Note that the weight of a restraint contribution may be 0.0, in which
+    case this contribution should not be used for restraining in calculations
 
-    8. The current draft supports the potential types
+    9. The current draft supports the potential types
 
       - 'undefined'
 
@@ -677,6 +652,9 @@ system. Only the expressions H%, HG2%, and H\* would appear in normal use.
     corresponding dihedral ('PHI', 'PSI', 'OMEGA', 'CHI1', 'CHI2', ...).
     This column is an information field, that supplements but does *not* replace
     or override the atom designations.
+    
+    5. Note that the weight of a restraint contribution may be 0.0, in which
+    case this contribution should not be used for restraining in calculations
 
   * Regarding Section 7. Optional: **RDC restraint lists(s)**
 
@@ -706,6 +684,9 @@ system. Only the expressions H%, HG2%, and H\* would appear in normal use.
 
     6. The 'distance_dependent' column shows whether the measurement depends on
     a variable interatom distance.
+    
+    7. Note that the weight of a restraint contribution may be 0.0, in which
+    case this contribution should not be used for restraining in calculations
 
   * Regarding Section 8. Optional: **Peak lists(s)**
 

--- a/specification/Overview.md
+++ b/specification/Overview.md
@@ -154,7 +154,8 @@ organised by data category (saveframe).
     5. Spectrum dimensions, peaks, restraints etc. are numbered starting at
     1 (and *not* at zero). Peaks and restraints are represented by more than one
     line in the corresponding loop; an additional column for the line number
-    ('ordinal') serves as the unique key for the loop.
+    ('index_id') serves as the unique key for the loop. These values are *not* 
+    preserved when reading and re-writing data.
 
     6. Peak numbers, restraint numbers, and datablock names / saveframe
     framecodes must  be kept unchanged by programs, so that they can be used as
@@ -462,7 +463,7 @@ expressions for Threonine and applying the standard regular expression rules.
 
   * Regarding Section 5. Optional: **Distance restraint lists(s)**
 
-    1. The ordinal column is a series of consecutive integers that serve to
+    1. The index_id column is a series of consecutive integers that serve to
     make each line unique. These values are *not* preserved when reading and
     re-writing data.
 
@@ -573,7 +574,7 @@ expressions for Threonine and applying the standard regular expression rules.
     We recommend using one of the values given below, but if these do
     not fit, others may be added. Values: 'chemical_shift', 'jcoupling'.
 
-    2. The ordinal column is a series of consecutive integers that serve to
+    2. The index_id column is a series of consecutive integers that serve to
     make each line unique. These values are *not* preserved when reading and
     re-writing data.
 
@@ -612,7 +613,7 @@ expressions for Threonine and applying the standard regular expression rules.
     not fit, others may be added. The value 'measured' should typically be
     sufficient.
 
-    4. The ordinal column is a series of consecutive integers that serve to
+    4. The index_id column is a series of consecutive integers that serve to
     make each line unique. These values are *not* preserved when reading and
     re-writing data.
 
@@ -668,7 +669,7 @@ expressions for Threonine and applying the standard regular expression rules.
     peaks, 3D peaks etc. For e.g. a 3D peak list, tags for dimensions 4 and
     higher are simply omitted. The maximum possible dimension is 15.
 
-    7. The ordinal column is a series of consecutive integers that serve to
+    7. The index_id column is a series of consecutive integers that serve to
     make each line unique. These values are *not* preserved when reading and
     re-writing data.
 

--- a/specification/Overview.md
+++ b/specification/Overview.md
@@ -464,65 +464,71 @@ system. Only the expressions H%, HG2%, and H\* would appear in normal use.
     position).The '\_nef_sequence.linking' column shows linear connection
     information.
 
-    Linear polymer residues (alpha-amino acids, DNA, and RNA) can have the
-    following linking values:
-      - 'start': the N-terminal or 5' end of a linear polymer
-      - 'end': the C-terminal or 3' end of a linear polymer
-      - 'middle': non-terminal residue in a linear polymer
-      - 'single': not part of a linear polymer.
-      - 'cyclic': first and last residue of a cyclic linear polymer; the
-        second 'cyclic' residue precedes the first cyclic residue in the
-        sequence
-      - 'break': A residue of linking type 'middle' that lacks a standard
-        linear polymer linkage on either or both sides.
-      - 'nonlinear': A residue that is not of linear polymer type always has
-        this linking value.
-      - 'dummy': A residue that is not part of the sequence proper,
-        e.g.  TNSR residue, or a linker residue (as used e.g. in CYANA).
-        Dummy residues that do not have a specific type (e.g. TNSR) should
-        use code UNK.
+      Linear polymer residues (alpha-amino acids, DNA, and RNA) can have the
+      following linking values:
+        - 'start': the N-terminal or 5' end of a linear polymer
+        - 'end': the C-terminal or 3' end of a linear polymer
+        - 'middle': non-terminal residue in a linear polymer
+        - 'single': not part of a linear polymer.
+        - 'cyclic': first and last residue of a cyclic linear polymer; the
+          second 'cyclic' residue precedes the first cyclic residue in the
+          sequence
+        - 'break': A residue of linking type 'middle' that lacks a standard
+          linear polymer linkage on either or both sides.
+        - 'nonlinear': A residue that is not of linear polymer type always has
+          this linking value.
+        - 'dummy': A residue that is not part of the sequence proper,
+          e.g.  TNSR residue, or a linker residue (as used e.g. in CYANA).
+          Dummy residues that do not have a specific type (e.g. TNSR) should
+          use code UNK.
 
-    Sequential linking within a given chain is inferred from the linking column
-    of consecutive residues. Residues of type 'start', 'middle', and 'end' must
-    have the appropriate link to the next/preceding residue in the same chain.
-    Sequences flanked by a 'start'-'end'
-    pair or a 'cyclic'-'cyclic' pair denote a linear or cyclic linear polymer,
-    respectively. The 'break' keyword is used when the first or last residue in
-    a linear polymer stretch is not a chain terminal variant. This might be the
-    case when only part of a sequence is given (discouraged but possible), or
-    when the next link is not a linear polymer link, e.g. for chain caps. Guy
-    Montelione (thanks!) gave an interesting example where the terminal -NH3
-    group was in an amide bond to a glutamate side chain in the same chain;
-    this topology would be given as 'break-middle-middle-middle-
-    ... -middle-end'. Only standard linear polymer links can be inferred from
-    the sequence; other links are given in the 'covalent_links' loop below.
+      Sequential linking within a given chain is inferred from the linking column
+      of consecutive residues. Residues of type 'start', 'middle', and 'end' must
+      have the appropriate link to the next/preceding residue in the same chain.
+      Sequences flanked by a 'start'-'end'
+      pair or a 'cyclic'-'cyclic' pair denote a linear or cyclic linear polymer,
+      respectively. The 'break' keyword is used when the first or last residue in
+      a linear polymer stretch is not a chain terminal variant. This might be the
+      case when only part of a sequence is given (discouraged but possible), or
+      when the next link is not a linear polymer link, e.g. for chain caps. Guy
+      Montelione (thanks!) gave an interesting example where the terminal -NH3
+      group was in an amide bond to a glutamate side chain in the same chain;
+      this topology would be given as 'break-middle-middle-middle-
+      ... -middle-end'. Only standard linear polymer links can be inferred from
+      the sequence; other links are given in the 'covalent_links' loop below.
 
-    By default residue variants are assumed to be the pH 7 forms,
-    specifically fully protonated HIS, LYS, ARG and N-terminus,
-    deprotonated ASP, GLU, and C-terminus, and deprotonated or disulfide
-    linked CYS (the PDB residue variants codes makes no distinction between
-    the two cases). The default types correspond to the DYANA types 'ARG+',
-    'ASP-', 'CYSS', 'GLU-', HIST+', and 'LYS+'. The optional
-    'residue_variant' column can be used for specifying protonation states
-    when these are known and different from the default.
+      By default residue variants are assumed to be the pH 7 forms,
+      specifically fully protonated HIS, LYS, ARG and N-terminus,
+      deprotonated ASP, GLU, and C-terminus, and deprotonated or disulfide
+      linked CYS (the PDB residue variants codes makes no distinction between
+      the two cases). The default types correspond to the DYANA types 'ARG+',
+      'ASP-', 'CYSS', 'GLU-', HIST+', and 'LYS+'. The optional
+      'residue_variant' column can be used for specifying protonation states
+      when these are known and different from the default.
 
-    The RCSB system requires a short introduction. The names are in three
-    parts, connected by underscores:
-      - first the three-letter residue code.
-      - second a backbone configuration marker, with the relevant values:
-        - 'LL' (L-amino acid, in middle of chain)
-        - 'LSN3' (L-amino acid, at start of chain, N-terminal protonated)
-        - 'LEO2' (L-amino acid, at end of chain, deprotonated C terminus)
-        - 'LEO2H' (L-amino acid, at end of chain, protonated C terminus)
-      - third a string showing which proton has been removed from the fully
-        protonated form.
+      The RCSB system requires a short introduction. The names are in three
+      parts, connected by underscores:
+        - first the three-letter residue code.
+        - second a backbone configuration marker, with the relevant values:
+          - 'LL' (L-amino acid, in middle of chain)
+          - 'LSN3' (L-amino acid, at start of chain, N-terminal protonated)
+          - 'LEO2' (L-amino acid, at end of chain, deprotonated C terminus)
+          - 'LEO2H' (L-amino acid, at end of chain, protonated C terminus)
+        - third a string showing which proton has been removed from the fully
+          protonated form.
 
-    See table below for supported variant codes.
+      See table below for supported variant codes.
 
-    **Supported residue variant codes**:
-    Note that each comes in four different versions, all for L-amino acids:
-     'LL' (middle of chain), 'LSN3' (N-terminal, protonated),
-     'LEO2' (C-terminal, deprotonated), and 'LEO2H' (C-terminal, protonated).
+    5. The ordinal column is a line number with consecutive integers starting
+    at 1. It is not preserved on import and re-export. The purpose it to
+    preserve the order of the lines (which is significant for specifying the
+    sequence) for implementations like (deposition) databases that do not use
+    ordered containers for the data.
+
+  **Supported residue variant codes**:
+  Note that each comes in four different versions, all for L-amino acids:
+   'LL' (middle of chain), 'LSN3' (N-terminal, protonated),
+   'LEO2' (C-terminal, deprotonated), and 'LEO2H' (C-terminal, protonated).
 
 | residue_name | dyana_type | protonation_code | example | comment |
 |-----|:-----|:-------|-----|-----|

--- a/specification/Overview.md
+++ b/specification/Overview.md
@@ -181,7 +181,7 @@ organised by data category (saveframe).
       '\_atom_site.auth_asym_id', '\_atom_site.auth_seq_id',
       '\_atom_site.auth_comp_id',  '\_atom_site.auth_atom_id' . This preserves
       NEF naming, and gives a mapping for each structure model to the
-      equivalent RCSB tags '\_atom_site.label_asym_id',
+      equivalent RCSB tags '\_atom_site.label_asym_id',D
       '\_atom_site.label_seq_id', '\_atom_site.pdbx_PDB_ins_code',
       '\_atom_site.label_comp_id', '\_atom_site.label_atom_id'. The
       NEF sequence_code is a string, combined from a numerical sequence
@@ -210,9 +210,19 @@ organised by data category (saveframe).
     expressed as ambiguous peak assignments or restraints. For the specific
     case of residue ranges we should notice that 'sequence_code' is a string,
     not an integer, which renders the concept of ranges rather unwieldy.
-
-      The supported wildcard expressions for standard residues will be given
-      later.
+    The supported wildcard expressions for standard residues are given
+    in the Residue_Variants.txt file.
+    
+    15. Elements and isotopes are deduced from the first letter of the atom name; i.e.
+    anything stareting with H is hydrogen, C is carbon, etc. The relevant isotope is 
+    deduced from context where necessary, e.g. NMR chemical shifts refer to 13C.
+    Isotope labeling patterns are not supported in this version of NEF.
+    For elements with two-letter abbreviations (e.g. Ca, Cd) the element must be specified
+    in the _nef_chemical_shift.element column. Similarly, non-default isotopes must be
+    specified in the _nef_chemical_shift.isotope_number column (e.g. 2H, 111Cd, 113Cd, ...).
+    Note that it is not possible to specify separet shifts for different isotopoes of the
+    same atom in a single shiftlist. In the unlikely case that this is necessary, hte two
+    shifts must be given in separate shiftlists.
 
   3. Identifiers
     1. NEF data block IDs (the string that follows 'data\_') *must* start with

--- a/specification/Overview.md
+++ b/specification/Overview.md
@@ -409,7 +409,7 @@ expressions.
     'upper-bound-parabolic-linear',  'lower-bound-parabolic-linear'
 
     3. '\_nef_sequence.linking': 'start', 'end', 'middle', 'cyclic', 'break',
-    'single', 'dummy', 'nonlinear'
+    'single', 'dummy'
 
     4. '\_nef_spectrum_dimension.folding': 'circular', 'mirror', 'none'
 
@@ -451,7 +451,7 @@ expressions.
     ligands, etc. are handled by using different chain codes.
 
     2. All programs must support the standard linear polymer residues and
-    their default states. Support for non-standard links, residues and residue
+    their default states. Support for non-standard links, residues or residue
     variants is not mandatory, but programs that do support these should read
     and write sequence descriptions accordingly.
 
@@ -472,41 +472,57 @@ expressions.
         - 'start': the N-terminal or 5' end of a linear polymer
         - 'end': the C-terminal or 3' end of a linear polymer
         - 'middle': non-terminal residue in a linear polymer
-        - 'single': not part of a linear polymer.
+        - 'single': d.	Linking 'single' is a 'free, single molecule' form. 
+          It used for any residue that does not participate in a regular linear 
+          polymer link, e.g. for free amino acids or for any residue that is 
+          not an alpha amino acid or nucleotide..
         - 'cyclic': first and last residue of a cyclic linear polymer; the
           second 'cyclic' residue precedes the first cyclic residue in the
           sequence
-        - 'break': A residue of linking type 'middle' that lacks a standard
-          linear polymer linkage on either or both sides.
-        - 'nonlinear': A residue that is not of linear polymer type always has
-          this linking value.
-        - 'dummy': A residue that is not part of the sequence proper,
-          e.g.  TNSR residue, or a linker residue (as used e.g. in CYANA).
-          Dummy residues that do not have a specific type (e.g. TNSR) should
-          use code UNK.
+        - 'break': A residue of linking type 'middle' that does not form a standard
+        sequential link to the following residue in the table,
+        - 'dummy': e.	Linking 'dummy' is used for dummy residues. By definition 
+        these do not contain atoms or participate in links. By convention, dummy 
+        residues used to represent tensor values have the residue name 'TNSR'
+      
+        Linkings 'middle', 'cyclic', or 'break' all signify a linear polymer 
+        residue with links in both directions
+        
+        
+       Sequential links are specified as follows:
 
-      Sequential linking within a given chain is inferred from the linking column
-      of consecutive residues. Residues of type 'start', 'middle', and 'end' must
-      have the appropriate link to the next/preceding residue in the same chain.
-      Sequences flanked by a 'start'-'end'
-      pair or a 'cyclic'-'cyclic' pair denote a linear or cyclic linear polymer,
-      respectively. The 'break' keyword is used when the first or last residue in
-      a linear polymer stretch is not a chain terminal variant. This might be the
-      case when only part of a sequence is given (discouraged but possible), or
-      when the next link is not a linear polymer link, e.g. for chain caps. Guy
-      Montelione (thanks!) gave an interesting example where the terminal -NH3
-      group was in an amide bond to a glutamate side chain in the same chain;
-      this topology would be given as 'break-middle-middle-middle-
-      ... -middle-end'. Only standard linear polymer links can be inferred from
-      the sequence; other links are given in the 'covalent_links' loop below.
+        - A normal sequence is given as a 'start' residue, followed by a series of 'middle' 
+          residues and terminated with an 'end' residue. 
 
-      By default residue variants are assumed to be the pH 7 forms. Programs
+        - If the 'start' ,'end' or both are omitted, or replaced by a form that does not 
+          allow links, the residue(s) at the end(s) of the sequence are NOT converted to 
+          terminal form, but remain in 'middle' form, with dangling ends.
+
+        - A series of 'middle' residues with a 'cyclic' residue at either end defines a cyclic 
+          stretch of linear polymer. 'cyclic' residues must appear in pairs, and all intervening 
+          residues must be of type 'middle'.
+
+        - 'single' residues do not partake in implicit sequential links, but may be linked 
+          through explicitly specified covalent bonds.
+
+        - The 'break' linking is used only to specify gaps in the sequence and has a very specific 
+          meaning: It signifies a residue of 'middle' form, that does NOT form a link to the 
+          successive residue. It s necessary only if  the successive residue is of type 'middle', 
+         'end', or 'break', and is likely to be very rarely used.
+
+      By default variants of standard residues are assumed to be the pH 7 forms, 
+      as specified in the Residue_Variants.txt file. Programs
       are required to support (in the sense of being able to read and 
       sensibly interpret) the standard 20 amino acids, 4 DNA and 4 RNA 
       nucleotides, toghether with their standard variants and wildcard atoms. 
       These are all defined in the specification/Residue_Variants.txt file.
+      Non-standard residues are assumed to be in the form given by the corresponding 
+      RCSB chemical compound.
 
-    5. The ordinal column is a line number with consecutive integers starting
+    5.Cis peptide bonds are indicated by the (Boolean) nef_sequence.cis_peptide column. 
+    The default value is 'false'.
+
+    6. The ordinal column is a line number with consecutive integers starting
     at 1. It is not preserved on import and re-export. The purpose it to
     preserve the order of the lines (which is significant for specifying the
     sequence) for implementations like (deposition) databases that do not use

--- a/specification/Residue_Variants.txt
+++ b/specification/Residue_Variants.txt
@@ -1,0 +1,464 @@
+# This file lists the standard residues (20 amino acids, 4 RNA, 4 DNA) that must be
+# supported by NEF-conforming programs.
+# For each is listed all atom names,
+# standard pseudoatom names, and supported variant codes
+# 'Additional atoms' are atoms that are part of the RCSB template 
+# but not of the default, pH 7 form.
+
+# Each residue is given as the linking ('middle') form. 'start' and 'end' residues are 
+# dealt with separately at the bottom of the file.
+
+# NEF standard residues - linking form:
+
+Code: 				ALA
+Name:				L-Alanine
+Default RCSB equivalent:	ALA_LL
+Std variant codes:		-
+Std form atoms:			N, O, C, CA, CB, 
+Std form atoms 1H:		H, HA, HB1, HB2, HB3
+Additional atoms:		-
+Std wildcard expressions:	HB%
+
+code: 				ARG
+Name:				L-Arginine    Default is side chain protonated form
+Default RCSB equivalent:	ARG_LL
+Std variant codes:		"-HH12" neutral side chain, matches ARG_LL_DHH12
+Std form atoms:			N, NE, NZ1, NZ2, O, C, CA, CB, CG, CD, CZ
+Std form atoms 1H:		H, HA, HB2, HB3, HG2, HG3, HD2, HD3, HE, HH11, HH12, HH21, HH22
+Additional atoms:		-
+Std wildcard expressions:	HB%, HG%, HD%, HH1%, HH2%, HH%, NZ%
+
+code: 				ASN
+Name:				L-Asparagine
+Default RCSB equivalent:	ASN_LL
+Std variant codes:		-
+Std form atoms:			N, ND2, O, OD1, C, CA, CB, CG
+Std form atoms 1H:		H, HA, HB2, HB3, HD21, HD22
+Additional atoms:		-
+Std wildcard expressions:	HB%, HD2%
+
+code: 				ASP
+Name:				L-Aspartate   Default is side chain deprotonated form
+Default RCSB equivalent:	ASP_LL_DHD2
+Std variant codes:		"+HD2"   neutral side chain, matches ASP_LL
+Std form atoms:			N, O, OD1, OD2, C, CA, CB, CG
+Std form atoms 1H:		H, HA, HB2, HB3
+Additional atoms:		HD2, DD2, TD2
+Std wildcard expressions:	HB%, OD%
+
+code: 				CYS
+Name:				L-Cysteine   Default is SH form
+Default RCSB equivalent:	CYS_LL
+Std variant codes:		"-HG"   deprotonated / disulfide linked side chain, matches CYS_LL_DHG
+Std form atoms:			N, O, C, CA, CB, SG
+Std form atoms 1H:		H, HA, HB2, HB3, HG
+Additional atoms:		-
+Std wildcard expressions:	HB%
+
+code: 				GLN
+Name:				L-Glutamine
+Default RCSB equivalent:	GLN_LL
+Std variant codes:		-
+Std form atoms:			N, NE2, O, OE1, C, CA, CB, CG, CD
+Std form atoms 1H:		H, HA, HB2, HB3, HG2, HG3, HE21, HE22
+Additional atoms:		-
+Std wildcard expressions:	HB%, HG%, HE2%
+
+code: 				GLU
+Name:				L-Glutamate   Default is side chain deprotonated form
+Default RCSB equivalent:	GLU_LL_DHE2
+Std variant codes:		"+HE2"   neutral side chain, matches GLU_LL
+Std form atoms:			N, O, OE1, OE2, C, CA, CB, CG, CD
+Std form atoms 1H:		H, HA, HB2, HB3, HG2, HG3
+Additional atoms:		HE2, DE2, TE2
+Std wildcard expressions:	HB%, HG%, OE%
+
+Code: 				GLY
+Name:				L-Glycine
+Default RCSB equivalent:	GLY_LL
+Std variant codes:		-
+Std form atoms:			N, O, C, CA
+Std form atoms 1H:		H, HA2, HA3
+Additional atoms:		-
+Std wildcard expressions:	HA%
+
+code: 				HIS
+Name:				L-Histidine   Default is neutral side chain form protonated on ND1  
+Default RCSB equivalent:	HIS_LL_DHE2
+Std variant codes:		"+HE2", (protonated side chain histidine, matches HIS_LL)
+				"-HD1,+HE2" (Neutral side chain histidine, proton on NE2, matches HIS_LL_DHD1)
+Std form atoms:			N, ND1, NE2, O, C, CA, CB, CG, CD2, CE1
+Std form atoms 1H:		H, HA, HB2, HB3, HD1, HD2, HE1
+Additional atoms:		HE2, DE2, TE2
+Std wildcard expressions:	HB%
+
+code: 				ILE
+Name:				L-Isoleucine
+Default RCSB equivalent:	ILE_LL
+Std variant codes:		-
+Std form atoms:			N, O, C, CA, CB, CG1, CG2, CD1
+Std form atoms 1H:		H, HA, HB, HG12, HG13, HG21, HG22, HG23, HD11, HD12, HD13
+Additional atoms:		-
+Std wildcard expressions:	HG1%, HG2%, HD1%, 
+
+code: 				LEU
+Name:				L-Leucine
+Default RCSB equivalent:	LEU_LL
+Std variant codes:		-
+Std form atoms:			N, O, C, CA, CB, CG, CD1, CD2
+Std form atoms 1H:		H, HA, HB2, HB3, HG, HD11, HD12, HD13, HD21, HD22, HD23
+Additional atoms:		-
+Std wildcard expressions:	HB%, HD1%, HD2%, HD%, 
+
+code: 				LYS
+Name:				L-Lysine   Default is side chain protonated form
+Default RCSB equivalent:	LYS_LL
+Std variant codes:		"-HZ3" neutral side chain, matches LYS_LL_DHZ3
+Std form atoms:			N, NZ, O, C, CA, CB, CG, CD, CE
+Std form atoms 1H:		H, HA, HB2, HB3, HG2, HG3, HD2, HD3, HE2, HE3, HZ1, HZ2, HZ3
+Additional atoms:		-
+Std wildcard expressions:	HB%, HG%, HD%, HE%, HZ%
+
+code: 				MET
+Name:				L-Methionine
+Default RCSB equivalent:	MET_LL
+Std variant codes:		-
+Std form atoms:			N, O, C, CA, CB, CG, SD, CE
+Std form atoms 1H:		H, HA, HB2, HB3, HG2, HG3, HE1, HE2, HE3
+Additional atoms:		-
+Std wildcard expressions:	HB%, HG%, HE%
+
+code: 				PHE
+Name:				L-Phenylalanine
+Default RCSB equivalent:	PHE_LL
+Std variant codes:		-
+Std form atoms:			N, O, C, CA, CB, CG, CD1, CD2, CE1, CE2, CZ
+Std form atoms 1H:		H, HA, HB2, HB3, HD1, HD2, HE1, HE2, HZ
+Additional atoms:		-
+Std wildcard expressions:	HB%, HD%, HE%, CD%, CE%
+
+code: 				PRO
+Name:				L-Proline
+Default RCSB equivalent:	PRO_LL
+Std variant codes:		-
+Std form atoms:			N, O, C, CA, CB, CG, CD
+Std form atoms 1H:		HA, HB2, HB3, HG2, HG3, HD2, HD3
+Additional atoms:		-
+Std wildcard expressions:	HB%, HG%, HD%
+
+code: 				SER
+Name:				L-Serine
+Default RCSB equivalent:	SER_LL
+Std variant codes:		-
+Std form atoms:			N, O, C, CA, CB, OG
+Std form atoms 1H:		H, HA, HB2, HB3, HG
+Additional atoms:		-
+Std wildcard expressions:	HB%
+
+code: 				THR
+Name:				L-Threonine
+Default RCSB equivalent:	THR_LL
+Std variant codes:		-
+Std form atoms:			N, O, OG1, C, CA, CB, CG2
+Std form atoms 1H:		H, HA, HB, HG1, HG21, HG22, HG23
+Additional atoms:		-
+Std wildcard expressions:	HG2%
+
+code: 				TRP
+Name:				L-Tryptophan
+Default RCSB equivalent:	TRP_LL
+Std variant codes:		-
+Std form atoms:			N, NE1, O, C, CA, CB, CG, CD1, CD2, CE2, CE3, CZ2, CZ3, CH2
+Std form atoms 1H:		H, HA, HB2, HB3, HD1, HE1, HE3, HZ2, HZ3, HH2
+Additional atoms:		-
+Std wildcard expressions:	HB%
+
+code: 				TYR
+Name:				L-Tyrosine   Default is neutral side chain form
+Default RCSB equivalent:	TYR_LL
+Std variant codes:		"-HH"   deprotonated side chain, matches TYR_LL_DHH
+Std form atoms:			N, O, OH, C, CA, CB, CG, CD1, CD2, CE1, CE2, CZ
+Std form atoms 1H:		H, HA, HB2, HB3, HD1, HD2, HE1, HE2, HH
+Additional atoms:		-
+Std wildcard expressions:	HB%, HD%, HE%, CD%, CE%
+
+code: 				VAL
+Name:				L-Valine
+Default RCSB equivalent:	VAL_LL
+Std variant codes:		-
+Std form atoms:			N, O, C, CA, CB, CG1, CG2
+Std form atoms 1H:		H, HA, HB, HG11, HG12, HG13, HG21, HG22, HG23
+Additional atoms:		-
+Std wildcard expressions:	HG1%, HG2%, HG%
+
+
+code:				DA
+Name:				2'-deoxyadenosine-5'-monophospate, phosphate deprotonated
+Default RCSB equivalent:	-
+Std variant codes:		-
+Std form atoms:			P, O3', O4', O5', OP1, OP2, C1', C2', C3', C4', C5'
+				N1, N3, N6, N7, N9, C2, C4, C5, C6, C8
+Std form atoms 1H:		H1', H2', H2'', H3', H4', H5', H5'', H2, H61, H62, H8
+Additional atoms:		HOP2
+Std wildcard expressions:	H2'*, H5'*, H6%
+
+code:				DC
+Name:				2'-deoxycytidine-5'-monophospate, phosphate deprotonated.
+Default RCSB equivalent:	-
+Std variant codes:		-
+Std form atoms:			P, O3', O4', O5', OP1, OP2, C1', C2', C3', C4', C5'
+				N1, N3, N4, O2, C2, C4, C5, C6
+Std form atoms 1H:		H1', H2', H2'', H3', H4', H5', H5'', H41, H42, H5, H6
+Additional atoms:		HOP2
+Std wildcard expressions:	H2'*, H5'*, H4%
+
+code:				DG
+Name:				2'-deoxyguanosine-5'-monophospate, phosphate deprotonated.
+Default RCSB equivalent:	-
+Std variant codes:		-
+Std form atoms:			P, O3', O4', O5', OP1, OP2, C1', C2', C3', C4', C5'
+				N1, N2, N3, N7, N9, O6, C2, C4, C5, C6, C8
+Std form atoms 1H:		H1', H2', H2'', H3', H4', H5', H5'', H1, H21, H22, H8
+Additional atoms:		HOP2
+Std wildcard expressions:	H2'*, H5'*, H2%
+
+code:				DT
+Name:				2'-deoxythymidine-5'-monophospate, phosphate deprotonated.
+Default RCSB equivalent:	-
+Std variant codes:		-
+Std form atoms:			P, O3', O4', O5', OP1, OP2, C1', C2', C3', C4', C5'
+				N1, N3, O2, O4, C2, C4, C5, C6, C7
+Std form atoms 1H:		H1', H2', H2'', H3', H4', H5', H5'', H3, H6, H71, H72, H73
+Additional atoms:		HOP2
+Std wildcard expressions:	H2'*, H5'*, H7%
+
+
+code:				A
+Name:				adenosine-5'-monophospate, phosphate deprotonated.
+Default RCSB equivalent:	-
+Std variant codes:		-
+Std form atoms:			P, O2', O3', O4', O5', OP1, OP2, C1', C2', C3', C4', C5'
+				N1, N3, N6, N7, N9, C2, C4, C5, C6, C8
+Std form atoms 1H:		H1', H2', HO2', H3', H4', H5', H5'', H2, H61, H62, H8
+Additional atoms:		HOP2
+Std wildcard expressions:	H5'*, H6%
+
+code:				C
+Name:				cytidine-5'-monophospate, phosphate deprotonated.
+Default RCSB equivalent:	-
+Std variant codes:		-
+Std form atoms:			P, O2', O3', O4', O5', OP1, OP2, C1', C2', C3', C4', C5'
+				N1, N3, N4, O2, C2, C4, C5, C6
+Std form atoms 1H:		H1', H2', HO2', H3', H4', H5', H5'', H41, H42, H5, H6
+Additional atoms:		HOP2
+Std wildcard expressions:	H5'*, H4%
+
+code:				G
+Name:				guanosine-5'-monophospate, phosphate deprotonated.
+Default RCSB equivalent:	-
+Std variant codes:		-
+Std form atoms:			P, O2', O3', O4', O5', OP1, OP2, C1', C2', C3', C4', C5'
+				N1, N2, N3, N7, N9, O6, C2, C4, C5, C6, C8
+Std form atoms 1H:		H1', H2', HO2', H3', H4', H5', H5'', H1, H21, H22, H8
+Additional atoms:		HOP2
+Std wildcard expressions:	H5'*, H2%
+
+code:				U
+Name:				uridine-5'-monophospate, phosphate deprotonated.
+Default RCSB equivalent:	-
+Std variant codes:		-
+Std form atoms:			P, O2', O3', O4', O5', OP1, OP2, C1', C2', C3', C4', C5'
+				N1, N3, O2, O4, C2, C4, C5, C6
+Std form atoms 1H:		H1', H2', HO2', H3', H4', H5', H5'', H3, H5, H6
+Additional atoms:		HOP2
+Std wildcard expressions:	H5'*, H7%
+
+
+
+
+All residues above are given in the linking form (linking code 'middle').
+Chain terminating forms differ as follows:
+
+NB - conforming programs must be able to *read* all the variant codes, but may convert them to a
+different representation inernally. For free residues (linking 'single') especially, some programs
+may well choose to convert all variants to a single template with default protonation state.
+
+
+Amino acids:
+- The N-terminal form (linking code 'start') has the backbone 'H' replaced by 'H1', 'H2', 'H3', with
+additional wildcard expressions 'H%'. Also, for each variant there is an additional variant
+with deprotonated amino terminal (code "-H3")
+- The C-terminal form has an extra 'Std form atom' 'OXT' and an extra 'Additional atom' 'HXT'.
+Also, for each variant there is an additional variant with protonated carboxy terminal (code "+HXT")
+- The non-linked form (linking code 'single') has the extra atoms and variant codes of both the 'start' 
+and 'end' forms.
+
+See the worked examples for CYS  and PRO (below) for illustrations.
+
+  
+Example of C/N terminal amino acids: Cysteine
+
+code: 				CYS (Example: N-terminal form)
+Name:				N-terminal L-Cysteine: Default has protonated N-terminus (matches CYS_LSN3)
+Std variant codes:		"-HG" (protonated N terminus, deprotonated side chain, matches CYS_LSN3_DHG)
+				"-H3" (deprotonated N terminus, protonated side chain, no exact RCSB match)
+				"-H3,-HG" (deprotonated N terminus, deprotonated side chain, no exact RCSB match)
+Std form atoms:			N, O, C, CA, CB, SG
+Std form atoms 1H		H1, H2, H3, HA, HB2, HB3, HG
+Additional atoms:		-
+Std wildcard expressions:	H%, HB%
+
+
+code: 				CYS (Example: C-terminal form)
+Name:				C-terminal L-Cysteine: Default has deprotonated carboxy terminus (matches CYS_LEO2)
+Std variant codes:		"-HG" (deprotonated side chain, deprotonated carboxy terminus, matches CYS_LEO2_DHG)
+				"+HXT" (protonated side chain, protonated carboxy terminus, matches CYS_LEO2H)
+				"-HG,+HXT" (deprotonated side chain, protonated carboxy terminus, matches CYS_LEO2H_DHG)
+
+Std form atoms:			N, O, OXT, C, CA, CB, SG
+Std form atoms 1H		H, HA, HB2, HB3, HG
+Additional atoms:		HXT
+Std wildcard expressions:	HB%
+
+
+code: 				CYS (Example: non-linked form)
+Name:				Unlinked L-Cysteine: Default is in zwitterion form (matches CYS_LFZW)
+Std variant codes:		"-HG" (deprotonated side chain, zwitterion form, matches CYS_LFZW_DHG)
+				"-H3,+HXT" (neutral groups form, matches CYS_LFOH)
+				"-H3,-HG,+HXT" (neutral backbone form, deprotonated side chain, matches CYS_LFOH_DHG)
+				"+HXT" (fully protonated form, no exact RCSB match)
+				"-HG,+HXT" (protonated backbone form, with deprotonated side chain, no exact RCSB match)
+				"-H3" (deprotonated backbone form, with protonated side chain, no exact RCSB match)
+				"-H3,-HG" (deprotonated backbone form, with deprotonated side chain, no exact RCSB match)
+Std form atoms:			N, O, OXT, C, CA, CB, SG
+Std form atoms 1H		H1, H2, H3, HA, HB2, HB3, HG
+Additional atoms:		HXT
+Std wildcard expressions:	HB%, H%
+
+
+code: 				PRO (Example, N-terminal form)
+Name:				N-terminal L-Proline: Default has protonated N-terminus (matches PRO_LSN3)
+Std variant codes:		"-H2,-H3,+H" (deprotonated N-terminus form, no exact RCSB match)
+Std form atoms:			N, O, C, CA, CB, CG, CD
+Std form atoms 1H		H2, H3, HA, HB2, HB3, HG2, HG3, HD2, HD3
+Additional atoms:		H
+Std wildcard expressions:	H%, HB%, HG%, HD%
+
+
+
+Nucleotides:
+- 5' terminal nucleotides (linking code 'start') lack the phosphate group in the default state. 
+- 'start' linking forms for the eight standard nucleotides are given below.
+  Each has a supported variant that includes the phoptae, with variant code "-HO5',+P,+OP1,+OP2.+OP3"
+- The 3' terminus (linking code 'end') has an extra 'Std form atom': HO3'
+- The non-linked form (linking code 'single') has two extra 'Std form atom's: OP3 and HO3'.
+  and an extra 'additional atom': HOP3
+  See example of free adenosine monophosphate, below.
+  
+
+Start linking forms of nucleotides:
+
+code:				DA
+Name:				2'-deoxyadenosine, 'start' linking
+Default RCSB equivalent:	-
+Std variant codes:		-HO5',+P,+OP1,+OP2.+OP3
+Std form atoms:			O3', O4', O5', C1', C2', C3', C4', C5'
+				N1, N3, N6, N7, N9, C2, C4, C5, C6, C8
+Std form atoms 1H:		H1', H2', H2'', H3', H4', H5', H5'', H2, H61, H62, H8, HO5'
+Additional atoms:		HOP2, HOP3, OP1, OP2, OP3, P
+Std wildcard expressions:	H2'*, H5'*, H6%
+
+code:				DC
+Name:				2'-deoxycytidine, 'start' linking
+Default RCSB equivalent:	-
+Std variant codes:		-HO5',+P,+OP1,+OP2.+OP3
+Std form atoms:			O3', O4', O5', C1', C2', C3', C4', C5'
+				N1, N3, N4, O2, C2, C4, C5, C6
+Std form atoms 1H:		H1', H2', H2'', H3', H4', H5', H5'', H41, H42, H5, H6, HO5'
+Additional atoms:		HOP2, HOP3, OP1, OP2, OP3, P
+Std wildcard expressions:	H2'*, H5'*, H4%
+
+code:				DG
+Name:				2'-deoxyguanosine, 'start' linking
+Default RCSB equivalent:	-
+Std variant codes:		-HO5',+P,+OP1,+OP2.+OP3
+Std form atoms:			O3', O4', O5', C1', C2', C3', C4', C5'
+				N1, N2, N3, N7, N9, O6, C2, C4, C5, C6, C8
+Std form atoms 1H:		H1', H2', H2'', H3', H4', H5', H5'', H1, H21, H22, H8, HO5'
+Additional atoms:		HOP2, HOP3, OP1, OP2, OP3, P
+Std wildcard expressions:	H2'*, H5'*, H2%
+
+code:				DT
+Name:				2'-deoxythymidine, 'start' linking
+Default RCSB equivalent:	-
+Std variant codes:		-HO5',+P,+OP1,+OP2.+OP3
+Std form atoms:			O3', O4', O5', C1', C2', C3', C4', C5'
+				N1, N3, O2, O4, C2, C4, C5, C6, C7
+Std form atoms 1H:		H1', H2', H2'', H3', H4', H5', H5'', H3, H6, H71, H72, H73, HO5'
+Additional atoms:		HOP2, HOP3, OP1, OP2, OP3, P
+Std wildcard expressions:	H2'*, H5'*, H7%
+
+
+code:				A
+Name:				adenosine, 'start' linking
+Default RCSB equivalent:	-
+Std variant codes:		-HO5',+P,+OP1,+OP2.+OP3
+Std form atoms:			O2', O3', O4', O5', C1', C2', C3', C4', C5'
+				N1, N3, N6, N7, N9, C2, C4, C5, C6, C8
+Std form atoms 1H:		H1', H2', HO2', H3', H4', H5', H5'', H2, H61, H62, H8, HO5'
+Additional atoms:		HOP2, HOP3, OP1, OP2, OP3, P
+Std wildcard expressions:	H5'*, H6%
+
+code:				C
+Name:				cytidine-, 'start' linking
+Default RCSB equivalent:	-
+Std variant codes:		-HO5',+P,+OP1,+OP2.+OP3
+Std form atoms:			O2', O3', O4', O5', C1', C2', C3', C4', C5'
+				N1, N3, N4, O2, C2, C4, C5, C6
+Std form atoms 1H:		H1', H2', HO2', H3', H4', H5', H5'', H41, H42, H5, H6, HO5'
+Additional atoms:		HOP2, HOP3, OP1, OP2, OP3, P
+Std wildcard expressions:	H5'*, H4%
+
+code:				G
+Name:				guanosine, 'start' linking
+Default RCSB equivalent:	-
+Std variant codes:		-HO5',+P,+OP1,+OP2.+OP3
+Std form atoms:			O2', O3', O4', O5', C1', C2', C3', C4', C5'
+				N1, N2, N3, N7, N9, O6, C2, C4, C5, C6, C8
+Std form atoms 1H:		H1', H2', HO2', H3', H4', H5', H5'', H1, H21, H22, H8, HO5'
+Additional atoms:		HOP2, HOP3, OP1, OP2, OP3, P
+Std wildcard expressions:	H5'*, H2%
+
+code:				U
+Name:				uridine, 'start' linking
+Default RCSB equivalent:	-
+Std variant codes:		-HO5',+P,+OP1,+OP2.+OP3
+Std form atoms:			O2', O3', O4', O5', C1', C2', C3', C4', C5'
+				N1, N3, O2, O4, C2, C4, C5, C6
+Std form atoms 1H:		H1', H2', HO2', H3', H4', H5', H5'', H3, H5, H6, HO5'
+Additional atoms:		HOP2, HOP3, OP1, OP2, OP3, P
+Std wildcard expressions:	H5'*, H7%
+
+
+Example: free adenosine-5'-monophospate
+
+code:				A
+Name:				adenosine-5'-monophospate, 'single' linking
+Default RCSB equivalent:	-
+Std variant codes:		-
+Std form atoms:			P, OP1, OP2, OP3, O2', O3', O4', O5', C1', C2', C3', C4', C5'
+				N1, N3, N6, N7, N9, C2, C4, C5, C6, C8
+Std form atoms 1H:		H1', H2', HO2', H3', H4', H5', H5'', H2, H61, H62, H8, HO3'
+Additional atoms:		HOP2, HOP3
+Std wildcard expressions:	H5'*, H6%
+
+
+
+For non-standard residues, the standard uses the RCSB chemical compounds, as they stand, as the default form, 
+and has no supported variant codes.
+
+
+
+It is possible to make variants freely with atoms either added or removed. 
+When adding atoms that are not in the 'Additional atoms' list, their bonds must be specified explicitly.
+There is no obligation on programs to interpret non-standard residues or non-standard variants.

--- a/specification/mmcif_nef.dic
+++ b/specification/mmcif_nef.dic
@@ -839,7 +839,7 @@ save_nef_sequence
           34  D  7    PHE  .          .            .
           35  D  8    CYS  .          -HD          .
           36  D  9    ASN  .          .            .
-          37  E  1    ASN  break      .            .
+          37  E  1    ASN  middle     .            .
           38  E  2    THR  middle     -HG1,-OG1    .
           39  E  3    ALA  middle     .            .
           40  E  4    PRO  middle     .            .
@@ -852,9 +852,9 @@ save_nef_sequence
           47  E  11   HIS  middle     .            .
           48  E  12   CYS  middle     .            .
           49  E  13   LYS  middle     .            .
-          50  E  14   ARG  break      .            .
-          51  E  15   MOH  nonlinear  -HO          .
-          52  E  16   GLC  nonlinear  -HO1         .
+          50  E  14   ARG  middle     .            .
+          51  E  15   MOH  single     -HO          .
+          52  E  16   GLC  single     -HO1         .
           53  F   1   GLY  start      .            .
           54  F   2   ILE  middle     .            .
           55  F   3   SER  middle     .            .
@@ -887,7 +887,7 @@ save_nef_sequence
 #
 # Chains F and G represent a chimeric protein, where (part of) chain G has been
 # inserted into chain F while maintaining the original numbering. Each chain is given as a
-# single block of residues, with the 'break' linking to show the chain gap, and the 
+# single block of residues, with the 'break' preceding a chain gap, and the 
 # nef_covalent_links loop to show the additional sequential links.
 ;
    #
@@ -963,7 +963,6 @@ save__nef_sequence.linking
        cyclic
        break
        single
-       nonlinear
        dummy
     stop_
 save_

--- a/specification/mmcif_nef.dic
+++ b/specification/mmcif_nef.dic
@@ -1146,7 +1146,6 @@ save_nef_chemical_shift_list
    _category_examples.case    
 ;   _nef_chemical_shift_list.sf_category                nef_chemical_shift_list
    _nef_chemical_shift_list.sf_framecode               nef_chemical_shift_list_bmrb21_str
-   _nef_chemical_shift_list.atom_chemical_shift_units  ppm
 ;
    #
 save_
@@ -1178,21 +1177,6 @@ save__nef_chemical_shift_list.sf_framecode
    _item_type.code  nef_framecode
    #
    _item_examples.case  nef_chemical_shift_list_bmrb21_str
-   #
-save_
-#
-save__nef_chemical_shift_list.atom_chemical_shift_units
-   #
-
-   _item_description.description  "The units of chemical shift values in the NEF_CHEMICAL_SHIFT category."
-   #
-   _item.name            "_nef_chemical_shift_list.atom_chemical_shift_units"
-   _item.category_id     nef_chemical_shift_list
-   _item.mandatory_code  yes
-   #
-   _item_type.code  word
-   #
-   _item_examples.case  ppm
    #
 save_
 

--- a/specification/mmcif_nef.dic
+++ b/specification/mmcif_nef.dic
@@ -1257,27 +1257,31 @@ save_nef_chemical_shift
       _nef_chemical_shift.atom_name
       _nef_chemical_shift.value
       _nef_chemical_shift.value_uncertainty
+      _nef_chemical_shift.element
+      _nef_chemical_shift.isotope_number
 
-      A	15	GLY	QA	 3.42	0.02
-      A 17      VAL     HG%      0.73   0.02
-      A 17      VAL     CG%     22.1    0.3
-      A 18      PHE     HB2      2.87   0.02
-      A 18      PHE     HB3      2.42   0.02
-      A 19      LEU     HBX      2.13   0.02
-      A 19      LEU     HBY      2.51   0.02
-      A 19      LEU     HDX%     0.87   0.02
-      A 19      LEU     HDY%     0.73   0.02
-      A 19      LEU     CDX     17.4    0.3
-      A 19      LEU     CDY     18.7    0.3
-      A 21      ALA     HA       4.17   0.02
-      A 21      ALA     H        8.33   0.02
-      A 21      ALA     HB%      1.34   0.02
-      A 23      LYS     HA       4.27   0.02
-      A 23      LYS     H        8.45   0.04
-      A 23      LYS     CA      43.2    0.25
-      A 23      LYS     N      123.45   0.4
-     @1 SS@231  GLX?    CAi-1   48.2     .
-     @1 SS@12      .    CAi-1   39.2     .
+      A	15	GLY	QA	 3.42	0.02   .   .
+      A 17      VAL     HG%      0.73   0.02   .   .
+      A 17      VAL     CG%     22.1    0.3    .   .
+      A 18      PHE     HB2      2.87   0.02   .   .
+      A 18      PHE     HB3      2.42   0.02   .   .
+      A 19      LEU     HBX      2.13   0.02   .   .
+      A 19      LEU     HBY      2.51   0.02   .   .
+      A 19      LEU     HDX%     0.87   0.02   .   .
+      A 19      LEU     HDY%     0.73   0.02   .   .
+      A 19      LEU     CDX     17.4    0.3    .   .
+      A 19      LEU     CDY     18.7    0.3    .   .
+      A 21      ALA     HA       4.17   0.02   .   .
+      A 21      ALA     H        8.33   0.02   .   .
+      A 21      ALA     HB%      1.34   0.02   .   .
+      A 23      LYS     HA       4.27   0.02   .   2
+      A 23      LYS     H        8.45   0.04   .   .
+      A 23      LYS     CA      43.2    0.25   .   .
+      A 23      LYS     N      123.45   0.4    .   .
+      B 1       CD      CD     -150.0   0      CD  113
+      C 1       CA      CA     -1.0     0      CA  .
+     @1 SS@231  GLX?    CAi-1   48.2     .     .   .
+     @1 SS@12      .    CAi-1   39.2     .     .   .
   stop_
   
 
@@ -1291,6 +1295,10 @@ save_nef_chemical_shift
 # Val 17 HG%/CG% show two methyl groups that overlap in both carbon and proton
 # dimensions.
 # 19 LEU HDX% is the methyl bound to CDX (and not to CDY).
+#
+# A LYS 23 HA is 2H rather than 1H
+# Chain B consists of a single Cadmium atom - the shift is for Cd 113.
+# Chain C consists of a single Calcium atom
 # The last two shifts (with chain_code @1) are unassigned but observed resonances,
 ;
 
@@ -1392,6 +1400,38 @@ save__nef_chemical_shift.value_uncertainty
    _item_type.code  float
    #
    _item_examples.case  0.02
+   #
+save_
+#
+#
+save__nef_chemical_shift.element
+   #
+
+   _item_description.description  "The chemical shift element code."
+   #
+   _item.name            "_nef_chemical_shift.element"
+   _item.category_id     nef_chemical_shift
+   _item.mandatory_code  no
+   #
+   _item_type.code  word
+   #
+   _item_examples.case  CA
+   #
+save_
+#
+#
+save__nef_chemical_shift.isotope_number
+   #
+
+   _item_description.description  "The chemical shift isotope mass number."
+   #
+   _item.name            "_nef_chemical_shift.isotope_number"
+   _item.category_id     nef_chemical_shift
+   _item.mandatory_code  no
+   #
+   _item_type.code  int
+   #
+   _item_examples.case  2
    #
 save_
 #

--- a/specification/mmcif_nef.dic
+++ b/specification/mmcif_nef.dic
@@ -799,67 +799,96 @@ save_nef_sequence
     _nef_sequence.residue_name
     _nef_sequence.linking
     _nef_sequence.residue_variant
+    _nef_sequence.cis_peptide
 
   # key: chain_code, sequence_code
 
-    A   13  ALA   start      .
-    A   14  TRP   middle     .
-    A   15  GLY   middle     .
-    A   16  ASN   middle     .
-    A   17  VAL   middle     .
-    A   18  PHE   middle     .
-    A   19  LEU   middle     .
-    A   20  CYS   middle     .
-    A   21  ALA   middle     .
-    A   22  THR   middle     .
-    A   23  LYS   middle     .
-    A   24  ASP   middle     .
-    A   25  HIS   end	     .
-    A   26  GLC   nonlinear  .
-    B   17  CYS   single     .
-    C    1  ATP   nonlinear  .
-    C  898  UNK   dummy      .
-    C  899  UNK   dummy      .
-    C  900  TNSR  dummy      .
-    D    1  GLY   cyclic     .
-    D    2  PRO   middle     .
-    D    3  ASP   middle     ASP_LL
-    D    4  GLY   middle     .
-    D    5  PRO   middle     .
-    D    6  ASP   cyclic     .
-    E    1  ASN   break      .
-    E    2  THR   middle     .
-    E    3  ALA   middle     .
-    E    4  PRO   middle     .
-    E    5  ALA   middle     .
-    E    6  GLU   middle     .
-    E    6B SER   middle     .
-    E    7  GLN   middle     .
-    E    8  GLU	  middle     GLU_LL
-    E    9  HIS	  middle     HIS_LL_DHD1
-    E   10  HIS	  middle     HIS_LL
-    E   11  CYS	  middle     .
-    E   12  LYS	  middle     LYS_LL_DHZ3
-    E   13  ARG	  break      ARG_LL_DHH12
-    E   14  MOH   nonlinear  .
+           1  A  13   ALA  start      .            .
+           2  A  14   TRP  middle     .            .
+           3  A  15   GLY  middle     .            .
+           4  A  16   ASN  middle     .            .
+           5  A  17   VAL  middle     .            .
+           6  A  18   PHE  middle     .            .
+           7  A  19   LEU  middle     .            .
+           8  A  20   CYS  middle     -HD          .
+           9  A  21   ALA  middle     .            .
+          10  A  22   THR  middle     .            .
+          11  A  23   LYS  middle     .            .
+          12  A  24   ASP  middle     .            .
+          13  A  24B  GLN  middle     .            .
+          14  A  24C  GLN  middle     .            .
+          15  A  24D  TYR  middle     .            .
+          16  A  25   HIS  end        -HD1,+HE2    .
+          17  B  17   CYS  single     -HD          .
+          18  C  1    GLY  cyclic     .            .
+          19  C  2    PRO  middle     .            true
+          20  C  3    ASP  middle     .            .
+          21  C  4    GLY  middle     .            .
+          22  C  5    PRO  middle     .            .
+          23  C  6    ASP  cyclic     .            .
+          24  D -3    TNSR dummy      .            .
+          25  D -2    LL2  dummy      .            .
+          26  D -1    LL1  dummy      .            .
+          27  D  0    LL   dummy      .            .
+          28  D  1    ALA  .          .            .
+          29  D  2    CYS  .          -HD          .
+          30  D  3    GLY  .          .            .
+          31  D  4    CYS  .          -HD          .
+          32  D  5    VAL  .          .            .
+          33  D  6    CYS  .          -HD          .
+          34  D  7    PHE  .          .            .
+          35  D  8    CYS  .          -HD          .
+          36  D  9    ASN  .          .            .
+          37  E  1    ASN  break      .            .
+          38  E  2    THR  middle     -HG1,-OG1    .
+          39  E  3    ALA  middle     .            .
+          40  E  4    PRO  middle     .            .
+          41  E  5    ALA  middle     .            .
+          42  E  6    GLU  middle     -OE2         .
+          43  E  7    SER  middle     .            .
+          44  E  8    GLN  middle     .            .
+          45  E  9    GLU  middle     .            .
+          46  E  10   HIS  middle     .            .
+          47  E  11   HIS  middle     .            .
+          48  E  12   CYS  middle     .            .
+          49  E  13   LYS  middle     .            .
+          50  E  14   ARG  break      .            .
+          51  E  15   MOH  nonlinear  -HO          .
+          52  E  16   GLC  nonlinear  -HO1         .
+          53  F   1   GLY  start      .            .
+          54  F   2   ILE  middle     .            .
+          55  F   3   SER  middle     .            .
+          56  F   4   THR  break      .            .
+          57  F  11   ASN  middle     .            .
+          58  F  12   SER  end        .            .
+          59  G   3   TYR  middle     .            .
+          60  G   4   GLY  middle     .            .
+          61  G   5   ALA  middle     .            .
   stop_
   
-# Chain A is a linear dodecapeptide (15-25), disulfide linked to a single
-# cysteine, with a glucose linked to THR 22
-# The GLC is given with chaincode A, the CYS with code B; both forms are allowed
+# The first column (ordinal) is a consecutive line number that does not persist  
+# when data are re-exported. It is there only to store the order that the lines
+# are givn inthe file (which is significant for specifying the sequence).
 #
-# Chain C is free ATP
+# Chain A is a linear hexadecapeptide (13-25), disulfide linked to a free cysteine (chain B)
+# HIS 25 is protonated on NE2 rather than ND1 (and deprotonated on the C terminated carboxyl).
 #
-# Chain D is a cyclic hexapeptide
+# Chain C is a cyclic hexapeptide, containing a cis-peptide bond at PRO 2.
+#
+# Chain D is a nonapeptide, defined with dangling ends (as might for instance be used
+# for CYANA). It contains two disulfide bonds, 2-6 and 4-8 - the connections are shown 
+# in the _nef_covalent_links loop. Four additional dummy residues have been added at the
+# N-terminal, three linker residues and a tensor-origin residue ('TNSR').
+# Note that there is NO sequential link between chains D and E, even though both have
+# dangling ends. Interchain links must always be given explictly in the _nef_covalent_links loop.
 #
 # Chain E has an amide bond between the backbone N of ASN 1 and the side chain carboxylate
 # of GLU 6, and a methyl ester cap.
 #
-# residue_variants default to the pH 7 forms, specifically protonated LYS, ARG, and N-terminus
-# and deprotonated ASP, GLU, and C-terminus. 
-# Chain E shows examples of how to specify the non-default forms supported by the NEF format.
-#
-# The current version does not allow specifying atoms that areremoved to give placxe for _nef_covalent_links# A change proposal is in place
+# Chains F and G represent a chimeric protein, where (part of) chain G has been
+# inserted into chain F while maintaining the original numbering. Each chain is given as a
+# single block of residues, with the 'break' linking to show the chain gap, and the 
+# nef_covalent_links loop to show the additional sequential links.
 ;
    #
 save_
@@ -957,8 +986,30 @@ these codes are not defined.
    #
    loop_
    _item_examples.case  
-     CYS_LL
-     ARG_LSN3_DHH12
+     -HD1,+HE2
+     -HZ3
+     +HD1
+   stop_
+   #
+save_
+#
+save__nef_sequence.cis_peptide
+   #
+
+   _item_description.description  
+;Boolean (default-false) descriubing whether the rsidue has a cis peptide bond.
+;
+   #
+   _item.name            "_nef_sequence.cis_peptide"
+   _item.category_id     nef_sequence
+   _item.mandatory_code  no
+   #
+   _item_type.code  boolean
+   #
+   loop_
+   _item_examples.case  
+     true
+     false
    stop_
    #
 save_

--- a/specification/mmcif_nef.dic
+++ b/specification/mmcif_nef.dic
@@ -789,14 +789,14 @@ save_nef_sequence
    _category_key.name
      "_nef_sequence.chain_code"  
      "_nef_sequence.sequence_code"  
-     "_nef_sequence.residue_type"  
+     "_nef_sequence.residue_name"  
    #
    _category_examples.detail  "Example 1"
    _category_examples.case    
 ;  loop_
     _nef_sequence.chain_code
     _nef_sequence.sequence_code
-    _nef_sequence.residue_type
+    _nef_sequence.residue_name
     _nef_sequence.linking
     _nef_sequence.residue_variant
 
@@ -898,12 +898,12 @@ save__nef_sequence.sequence_code
    #
 save_
 #
-save__nef_sequence.residue_type
+save__nef_sequence.residue_name
    #
 
    _item_description.description  "The author provided residue name."
    #
-   _item.name            "_nef_sequence.residue_type"
+   _item.name            "_nef_sequence.residue_name"
    _item.category_id     nef_sequence
    _item.mandatory_code  yes
    #
@@ -978,12 +978,12 @@ save_nef_covalent_links
    loop_
    _category_key.name
      "_nef_covalent_links.chain_code_1"  
-     "_nef_covalent_links.residue_type_1"  
+     "_nef_covalent_links.residue_name_1"  
      "_nef_covalent_links.sequence_code_1"  
      "_nef_covalent_links.atom_name_1"  
      "_nef_covalent_links.chain_code_2"  
      "_nef_covalent_links.sequence_code_2"   
-     "_nef_covalent_links.residue_type_2" 
+     "_nef_covalent_links.residue_name_2" 
      "_nef_covalent_links.atom_name_2"  
    #
    _category_examples.detail  "Example 1"
@@ -991,11 +991,11 @@ save_nef_covalent_links
 ;   loop_
      _nef_covalent_links.chain_code_1
      _nef_covalent_links.sequence_code_1
-     _nef_covalent_links.residue_type_1
+     _nef_covalent_links.residue_name_1
      _nef_covalent_links.atom_name_1
      _nef_covalent_links.chain_code_2
      _nef_covalent_links.sequence_code_2
-     _nef_covalent_links.residue_type_2
+     _nef_covalent_links.residue_name_2
      _nef_covalent_links.atom_name_2
      B   3   CYS   SG   B   6   CYS   SG
      B   5   THR   OG1  B   9   GLN   C
@@ -1034,12 +1034,12 @@ save__nef_covalent_links.sequence_code_1
    #
 save_
 #
-save__nef_covalent_links.residue_type_1
+save__nef_covalent_links.residue_name_1
    #
 
    _item_description.description  "The author provided name for the first partner residue."
    #
-   _item.name            "_nef_covalent_links.residue_type_1"
+   _item.name            "_nef_covalent_links.residue_name_1"
    _item.category_id     nef_covalent_links
    _item.mandatory_code  yes
    #
@@ -1094,12 +1094,12 @@ save__nef_covalent_links.sequence_code_2
    #
 save_
 #
-save__nef_covalent_links.residue_type_2
+save__nef_covalent_links.residue_name_2
    #
 
    _item_description.description  "The author provided name for the second partner residue."
    #
-   _item.name            "_nef_covalent_links.residue_type_2"
+   _item.name            "_nef_covalent_links.residue_name_2"
    _item.category_id     nef_covalent_links
    _item.mandatory_code  yes
    #
@@ -1211,7 +1211,7 @@ save_nef_chemical_shift
    _category_key.name  
      "_nef_chemical_shift.chain_code"  
      "_nef_chemical_shift.sequence_code"  
-     "_nef_chemical_shift.residue_type"  
+     "_nef_chemical_shift.residue_name"  
      "_nef_chemical_shift.atom_name"
    #
    _category_examples.detail  "Example 1"
@@ -1219,7 +1219,7 @@ save_nef_chemical_shift
 ;   loop_
       _nef_chemical_shift.chain_code
       _nef_chemical_shift.sequence_code
-      _nef_chemical_shift.residue_type
+      _nef_chemical_shift.residue_name
       _nef_chemical_shift.atom_name
       _nef_chemical_shift.value
       _nef_chemical_shift.value_uncertainty
@@ -1297,12 +1297,12 @@ save__nef_chemical_shift.sequence_code
    #
 save_
 #
-save__nef_chemical_shift.residue_type
+save__nef_chemical_shift.residue_name
    #
 
    _item_description.description  "The author provided residue name."
    #
-   _item.name            "_nef_chemical_shift.residue_type"
+   _item.name            "_nef_chemical_shift.residue_name"
    _item.category_id     nef_chemical_shift
    _item.mandatory_code  yes
    #
@@ -1473,11 +1473,11 @@ save_nef_distance_restraint
     _nef_distance_restraint.restraint_combination_id
     _nef_distance_restraint.chain_code_1
     _nef_distance_restraint.sequence_code_1
-    _nef_distance_restraint.residue_type_1
+    _nef_distance_restraint.residue_name_1
     _nef_distance_restraint.atom_name_1
     _nef_distance_restraint.chain_code_2
     _nef_distance_restraint.sequence_code_2
-    _nef_distance_restraint.residue_type_2
+    _nef_distance_restraint.residue_name_2
     _nef_distance_restraint.atom_name_2
     _nef_distance_restraint.weight
     _nef_distance_restraint.target_value
@@ -1592,12 +1592,12 @@ save__nef_distance_restraint.sequence_code_1
    #
 save_
 #
-save__nef_distance_restraint.residue_type_1
+save__nef_distance_restraint.residue_name_1
    #
 
    _item_description.description  "The author provided name for the first partner residue."
    #
-   _item.name            "_nef_distance_restraint.residue_type_1"
+   _item.name            "_nef_distance_restraint.residue_name_1"
    _item.category_id     nef_distance_restraint
    _item.mandatory_code  yes
    #
@@ -1652,12 +1652,12 @@ save__nef_distance_restraint.sequence_code_2
    #
 save_
 #
-save__nef_distance_restraint.residue_type_2
+save__nef_distance_restraint.residue_name_2
    #
 
    _item_description.description  "The author provided name for the second partner residue."
    #
-   _item.name            "_nef_distance_restraint.residue_type_2"
+   _item.name            "_nef_distance_restraint.residue_name_2"
    _item.category_id     nef_distance_restraint
    _item.mandatory_code  yes
    #
@@ -1899,19 +1899,19 @@ save_nef_dihedral_restraint
     _nef_dihedral_restraint.restraint_combination_id
     _nef_dihedral_restraint.chain_code_1
     _nef_dihedral_restraint.sequence_code_1
-    _nef_dihedral_restraint.residue_type_1
+    _nef_dihedral_restraint.residue_name_1
     _nef_dihedral_restraint.atom_name_1
     _nef_dihedral_restraint.chain_code_2
     _nef_dihedral_restraint.sequence_code_2
-    _nef_dihedral_restraint.residue_type_2
+    _nef_dihedral_restraint.residue_name_2
     _nef_dihedral_restraint.atom_name_2
     _nef_dihedral_restraint.chain_code_3
     _nef_dihedral_restraint.sequence_code_3
-    _nef_dihedral_restraint.residue_type_3
+    _nef_dihedral_restraint.residue_name_3
     _nef_dihedral_restraint.atom_name_3
     _nef_dihedral_restraint.chain_code_4
     _nef_dihedral_restraint.sequence_code_4
-    _nef_dihedral_restraint.residue_type_4
+    _nef_dihedral_restraint.residue_name_4
     _nef_dihedral_restraint.atom_name_4
     _nef_dihedral_restraint.weight
     _nef_dihedral_restraint.target_value
@@ -2019,12 +2019,12 @@ save__nef_dihedral_restraint.sequence_code_1
    #
 save_
 #
-save__nef_dihedral_restraint.residue_type_1
+save__nef_dihedral_restraint.residue_name_1
    #
 
    _item_description.description  "The author provided name for the first partner residue."
    #
-   _item.name            "_nef_dihedral_restraint.residue_type_1"
+   _item.name            "_nef_dihedral_restraint.residue_name_1"
    _item.category_id     nef_dihedral_restraint
    _item.mandatory_code  yes
    #
@@ -2079,12 +2079,12 @@ save__nef_dihedral_restraint.sequence_code_2
    #
 save_
 #
-save__nef_dihedral_restraint.residue_type_2
+save__nef_dihedral_restraint.residue_name_2
    #
 
    _item_description.description  "The author provided name for the second partner residue."
    #
-   _item.name            "_nef_dihedral_restraint.residue_type_2"
+   _item.name            "_nef_dihedral_restraint.residue_name_2"
    _item.category_id     nef_dihedral_restraint
    _item.mandatory_code  yes
    #
@@ -2139,12 +2139,12 @@ save__nef_dihedral_restraint.sequence_code_3
    #
 save_
 #
-save__nef_dihedral_restraint.residue_type_3
+save__nef_dihedral_restraint.residue_name_3
    #
 
    _item_description.description  "The author provided name for the third partner residue."
    #
-   _item.name            "_nef_dihedral_restraint.residue_type_3"
+   _item.name            "_nef_dihedral_restraint.residue_name_3"
    _item.category_id     nef_dihedral_restraint
    _item.mandatory_code  yes
    #
@@ -2199,12 +2199,12 @@ save__nef_dihedral_restraint.sequence_code_4
    #
 save_
 #
-save__nef_dihedral_restraint.residue_type_4
+save__nef_dihedral_restraint.residue_name_4
    #
 
    _item_description.description  "The author provided name for the fourth partner residue."
    #
-   _item.name            "_nef_dihedral_restraint.residue_type_4"
+   _item.name            "_nef_dihedral_restraint.residue_name_4"
    _item.category_id     nef_dihedral_restraint
    _item.mandatory_code  yes
    #
@@ -2498,12 +2498,12 @@ save__nef_rdc_restraint_list.tensor_sequence_code
    #
 save_
 #
-save__nef_rdc_restraint_list.tensor_residue_type
+save__nef_rdc_restraint_list.tensor_residue_name
    #
 
    _item_description.description  "The author provided residue code for a dummy residue specifying the location and orientation of the tensor."
    #
-   _item.name            "_nef_rdc_restraint_list.tensor_residue_type"
+   _item.name            "_nef_rdc_restraint_list.tensor_residue_name"
    _item.category_id     nef_rdc_restraint_list
    _item.mandatory_code  no
    #
@@ -2535,11 +2535,11 @@ save_nef_rdc_restraint
     _nef_rdc_restraint.restraint_combination_id
     _nef_rdc_restraint.chain_code_1
     _nef_rdc_restraint.sequence_code_1
-    _nef_rdc_restraint.residue_type_1
+    _nef_rdc_restraint.residue_name_1
     _nef_rdc_restraint.atom_name_1
     _nef_rdc_restraint.chain_code_2
     _nef_rdc_restraint.sequence_code_2
-    _nef_rdc_restraint.residue_type_2
+    _nef_rdc_restraint.residue_name_2
     _nef_rdc_restraint.atom_name_2
     _nef_rdc_restraint.weight
     _nef_rdc_restraint.target_value
@@ -2636,12 +2636,12 @@ save__nef_rdc_restraint.sequence_code_1
    #
 save_
 #
-save__nef_rdc_restraint.residue_type_1
+save__nef_rdc_restraint.residue_name_1
    #
 
    _item_description.description  "The author provided name for the first partner residue."
    #
-   _item.name            "_nef_rdc_restraint.residue_type_1"
+   _item.name            "_nef_rdc_restraint.residue_name_1"
    _item.category_id     nef_rdc_restraint
    _item.mandatory_code  yes
    #
@@ -2696,12 +2696,12 @@ save__nef_rdc_restraint.sequence_code_2
    #
 save_
 #
-save__nef_rdc_restraint.residue_type_2
+save__nef_rdc_restraint.residue_name_2
    #
 
    _item_description.description  "The author provided name for the second partner residue."
    #
-   _item.name            "_nef_rdc_restraint.residue_type_2"
+   _item.name            "_nef_rdc_restraint.residue_name_2"
    _item.category_id     nef_rdc_restraint
    _item.mandatory_code  yes
    #
@@ -3318,15 +3318,15 @@ save_nef_peak
       _nef_peak.position_uncertainty_3
       _nef_peak.chain_code_1
       _nef_peak.sequence_code_1
-      _nef_peak.residue_type_1
+      _nef_peak.residue_name_1
       _nef_peak.atom_name_1
       _nef_peak.chain_code_2
       _nef_peak.sequence_code_2
-      _nef_peak.residue_type_2
+      _nef_peak.residue_name_2
       _nef_peak.atom_name_2
       _nef_peak.chain_code_3
       _nef_peak.sequence_code_3
-      _nef_peak.residue_type_3
+      _nef_peak.residue_name_3
       _nef_peak.atom_name_3
 
   #key: ordinal
@@ -3383,63 +3383,63 @@ save_nef_peak
       _nef_peak.position_uncertainty_15
       _nef_peak.chain_code_1
       _nef_peak.sequence_code_1
-      _nef_peak.residue_type_1
+      _nef_peak.residue_name_1
       _nef_peak.atom_name_1
       _nef_peak.chain_code_2
       _nef_peak.sequence_code_2
-      _nef_peak.residue_type_2
+      _nef_peak.residue_name_2
       _nef_peak.atom_name_2
       _nef_peak.chain_code_3
       _nef_peak.sequence_code_3
-      _nef_peak.residue_type_3
+      _nef_peak.residue_name_3
       _nef_peak.atom_name_3
       _nef_peak.chain_code_4
       _nef_peak.sequence_code_4
-      _nef_peak.residue_type_4
+      _nef_peak.residue_name_4
       _nef_peak.atom_name_4
       _nef_peak.chain_code_5
       _nef_peak.sequence_code_5
-      _nef_peak.residue_type_5
+      _nef_peak.residue_name_5
       _nef_peak.atom_name_5
       _nef_peak.chain_code_6
       _nef_peak.sequence_code_6
-      _nef_peak.residue_type_6
+      _nef_peak.residue_name_6
       _nef_peak.atom_name_6
       _nef_peak.chain_code_7
       _nef_peak.sequence_code_7
-      _nef_peak.residue_type_7
+      _nef_peak.residue_name_7
       _nef_peak.atom_name_7
       _nef_peak.chain_code_8
       _nef_peak.sequence_code_8
-      _nef_peak.residue_type_8
+      _nef_peak.residue_name_8
       _nef_peak.atom_name_8
       _nef_peak.chain_code_9
       _nef_peak.sequence_code_9
-      _nef_peak.residue_type_9
+      _nef_peak.residue_name_9
       _nef_peak.atom_name_9
       _nef_peak.chain_code_10
       _nef_peak.sequence_code_10
-      _nef_peak.residue_type_10
+      _nef_peak.residue_name_10
       _nef_peak.atom_name_10
       _nef_peak.chain_code_11
       _nef_peak.sequence_code_11
-      _nef_peak.residue_type_11
+      _nef_peak.residue_name_11
       _nef_peak.atom_name_11
       _nef_peak.chain_code_12
       _nef_peak.sequence_code_12
-      _nef_peak.residue_type_12
+      _nef_peak.residue_name_12
       _nef_peak.atom_name_12
       _nef_peak.chain_code_13
       _nef_peak.sequence_code_13
-      _nef_peak.residue_type_13
+      _nef_peak.residue_name_13
       _nef_peak.atom_name_13
       _nef_peak.chain_code_14
       _nef_peak.sequence_code_14
-      _nef_peak.residue_type_14
+      _nef_peak.residue_name_14
       _nef_peak.atom_name_14
       _nef_peak.chain_code_15
       _nef_peak.sequence_code_15
-      _nef_peak.residue_type_15
+      _nef_peak.residue_name_15
       _nef_peak.atom_name_15
 
 
@@ -4022,12 +4022,12 @@ save__nef_peak.sequence_code_1
    #
 save_
 #
-save__nef_peak.residue_type_1
+save__nef_peak.residue_name_1
    #
 
    _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 1 of the spectrum."
    #
-   _item.name            "_nef_peak.residue_type_1"
+   _item.name            "_nef_peak.residue_name_1"
    _item.category_id     nef_peak
    _item.mandatory_code  no
    #
@@ -4083,12 +4083,12 @@ save__nef_peak.sequence_code_2
    #
 save_
 #
-save__nef_peak.residue_type_2
+save__nef_peak.residue_name_2
    #
 
    _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 2 of the spectrum."
    #
-   _item.name            "_nef_peak.residue_type_2"
+   _item.name            "_nef_peak.residue_name_2"
    _item.category_id     nef_peak
    _item.mandatory_code  no
    #
@@ -4144,12 +4144,12 @@ save__nef_peak.sequence_code_3
    #
 save_
 #
-save__nef_peak.residue_type_3
+save__nef_peak.residue_name_3
    #
 
    _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 3 of the spectrum."
    #
-   _item.name            "_nef_peak.residue_type_3"
+   _item.name            "_nef_peak.residue_name_3"
    _item.category_id     nef_peak
    _item.mandatory_code  no
    #
@@ -4205,12 +4205,12 @@ save__nef_peak.sequence_code_4
    #
 save_
 #
-save__nef_peak.residue_type_4
+save__nef_peak.residue_name_4
    #
 
    _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 4 of the spectrum."
    #
-   _item.name            "_nef_peak.residue_type_4"
+   _item.name            "_nef_peak.residue_name_4"
    _item.category_id     nef_peak
    _item.mandatory_code  no
    #
@@ -4266,12 +4266,12 @@ save__nef_peak.sequence_code_5
    #
 save_
 #
-save__nef_peak.residue_type_5
+save__nef_peak.residue_name_5
    #
 
    _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 5 of the spectrum."
    #
-   _item.name            "_nef_peak.residue_type_5"
+   _item.name            "_nef_peak.residue_name_5"
    _item.category_id     nef_peak
    _item.mandatory_code  no
    #
@@ -4327,12 +4327,12 @@ save__nef_peak.sequence_code_6
    #
 save_
 #
-save__nef_peak.residue_type_6
+save__nef_peak.residue_name_6
    #
 
    _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 6 of the spectrum."
    #
-   _item.name            "_nef_peak.residue_type_6"
+   _item.name            "_nef_peak.residue_name_6"
    _item.category_id     nef_peak
    _item.mandatory_code  no
    #
@@ -4388,12 +4388,12 @@ save__nef_peak.sequence_code_7
    #
 save_
 #
-save__nef_peak.residue_type_7
+save__nef_peak.residue_name_7
    #
 
    _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 7 of the spectrum."
    #
-   _item.name            "_nef_peak.residue_type_7"
+   _item.name            "_nef_peak.residue_name_7"
    _item.category_id     nef_peak
    _item.mandatory_code  no
    #
@@ -4449,12 +4449,12 @@ save__nef_peak.sequence_code_8
    #
 save_
 #
-save__nef_peak.residue_type_8
+save__nef_peak.residue_name_8
    #
 
    _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 8 of the spectrum."
    #
-   _item.name            "_nef_peak.residue_type_8"
+   _item.name            "_nef_peak.residue_name_8"
    _item.category_id     nef_peak
    _item.mandatory_code  no
    #
@@ -4510,12 +4510,12 @@ save__nef_peak.sequence_code_9
    #
 save_
 #
-save__nef_peak.residue_type_9
+save__nef_peak.residue_name_9
    #
 
    _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 9 of the spectrum."
    #
-   _item.name            "_nef_peak.residue_type_9"
+   _item.name            "_nef_peak.residue_name_9"
    _item.category_id     nef_peak
    _item.mandatory_code  no
    #
@@ -4571,12 +4571,12 @@ save__nef_peak.sequence_code_10
    #
 save_
 #
-save__nef_peak.residue_type_10
+save__nef_peak.residue_name_10
    #
 
    _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 10 of the spectrum."
    #
-   _item.name            "_nef_peak.residue_type_10"
+   _item.name            "_nef_peak.residue_name_10"
    _item.category_id     nef_peak
    _item.mandatory_code  no
    #
@@ -4632,12 +4632,12 @@ save__nef_peak.sequence_code_11
    #
 save_
 #
-save__nef_peak.residue_type_11
+save__nef_peak.residue_name_11
    #
 
    _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 11 of the spectrum."
    #
-   _item.name            "_nef_peak.residue_type_11"
+   _item.name            "_nef_peak.residue_name_11"
    _item.category_id     nef_peak
    _item.mandatory_code  no
    #
@@ -4693,12 +4693,12 @@ save__nef_peak.sequence_code_12
    #
 save_
 #
-save__nef_peak.residue_type_12
+save__nef_peak.residue_name_12
    #
 
    _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 12 of the spectrum."
    #
-   _item.name            "_nef_peak.residue_type_12"
+   _item.name            "_nef_peak.residue_name_12"
    _item.category_id     nef_peak
    _item.mandatory_code  no
    #
@@ -4754,12 +4754,12 @@ save__nef_peak.sequence_code_13
    #
 save_
 #
-save__nef_peak.residue_type_13
+save__nef_peak.residue_name_13
    #
 
    _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 13 of the spectrum."
    #
-   _item.name            "_nef_peak.residue_type_13"
+   _item.name            "_nef_peak.residue_name_13"
    _item.category_id     nef_peak
    _item.mandatory_code  no
    #
@@ -4815,12 +4815,12 @@ save__nef_peak.sequence_code_14
    #
 save_
 #
-save__nef_peak.residue_type_14
+save__nef_peak.residue_name_14
    #
 
    _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 14 of the spectrum."
    #
-   _item.name            "_nef_peak.residue_type_14"
+   _item.name            "_nef_peak.residue_name_14"
    _item.category_id     nef_peak
    _item.mandatory_code  no
    #
@@ -4876,12 +4876,12 @@ save__nef_peak.sequence_code_15
    #
 save_
 #
-save__nef_peak.residue_type_15
+save__nef_peak.residue_name_15
    #
 
    _item_description.description  "The author provided identifier for the residue code for the nuclear assignment associated with dimension 15 of the spectrum."
    #
-   _item.name            "_nef_peak.residue_type_15"
+   _item.name            "_nef_peak.residue_name_15"
    _item.category_id     nef_peak
    _item.mandatory_code  no
    #

--- a/specification/mmcif_nef.dic
+++ b/specification/mmcif_nef.dic
@@ -1463,12 +1463,12 @@ save_nef_distance_restraint
    #
    _category_group.id             nef_group
    #   #
-   _category_key.name             '_nef_distance_restraint.ordinal'
+   _category_key.name             '_nef_distance_restraint.index_id'
    #
    _category_examples.detail  "Example 1"
    _category_examples.case    
 ;  loop_
-    _nef_distance_restraint.ordinal
+    _nef_distance_restraint.index_id
     _nef_distance_restraint.restraint_id
     _nef_distance_restraint.restraint_combination_id
     _nef_distance_restraint.chain_code_1
@@ -1496,7 +1496,7 @@ save_nef_distance_restraint
     6  8  .   E 6B   SER  HB2  A 24  ASP  HBY 1.00 4.4  0.4   3.6  4.1  5.2  5.7
   stop_
 
-  # The first column (ordinal) is a consecutive line number that does not persist  
+  # The first column (index_id) is a consecutive line number that does not persist  
   # when data are re-exported
   # The second column gives the restraint ID.
   # Lines 9cxontgributions) with the same restraint_id are combined into a single restraint
@@ -1512,12 +1512,12 @@ save_nef_distance_restraint
    #
 save_
 #
-save__nef_distance_restraint.ordinal
+save__nef_distance_restraint.index_id
    #
 
    _item_description.description  "Line number for the restraint loop - not preserved when data are read."
    #
-   _item.name            "_nef_distance_restraint.ordinal"
+   _item.name            "_nef_distance_restraint.index_id"
    _item.category_id     nef_distance_restraint
    _item.mandatory_code  yes
    #
@@ -1889,12 +1889,12 @@ save_nef_dihedral_restraint
    #
    _category_group.id  nef_group
    #
-   _category_key.name  "_nef_dihedral_restraint.ordinal"
+   _category_key.name  "_nef_dihedral_restraint.index_id"
    #
    _category_examples.detail  "Example 1"
    _category_examples.case    
 ;  loop_
-    _nef_dihedral_restraint.ordinal
+    _nef_dihedral_restraint.index_id
     _nef_dihedral_restraint.restraint_id
     _nef_dihedral_restraint.restraint_combination_id
     _nef_dihedral_restraint.chain_code_1
@@ -1936,12 +1936,12 @@ stop_
    #
 save_
 
-save__nef_dihedral_restraint.ordinal
+save__nef_dihedral_restraint.index_id
    #
 
    _item_description.description  "Line number for the restraint loop - not preserved when data are read."
    #
-   _item.name            "_nef_dihedral_restraint.ordinal"
+   _item.name            "_nef_dihedral_restraint.index_id"
    _item.category_id     nef_dihedral_restraint
    _item.mandatory_code  yes
    #
@@ -2524,13 +2524,13 @@ save_nef_rdc_restraint
    #
    _category_group.id             nef_group
    #
-   _category_key.name             '_nef_rdc_restraint.ordinal'
+   _category_key.name             '_nef_rdc_restraint.index_id'
    #
    _category_examples.detail      "Example 1"
    _category_examples.case    
 ;
   loop_
-    _nef_rdc_restraint.ordinal
+    _nef_rdc_restraint.index_id
     _nef_rdc_restraint.restraint_id
     _nef_rdc_restraint.restraint_combination_id
     _nef_rdc_restraint.chain_code_1
@@ -2559,12 +2559,12 @@ save_nef_rdc_restraint
    #
 save_
 #
-save__nef_rdc_restraint.ordinal
+save__nef_rdc_restraint.index_id
    #
 
    _item_description.description  "Line number for the restraint loop - not preserved when data are read."
    #
-   _item.name            "_nef_rdc_restraint.ordinal"
+   _item.name            "_nef_rdc_restraint.index_id"
    _item.category_id     nef_rdc_restraint
    _item.mandatory_code  yes
    #
@@ -3295,7 +3295,7 @@ save_nef_peak
    #
    _category_group.id             nef_group
    #
-   _category_key.name             "_nef_peak.ordinal"
+   _category_key.name             "_nef_peak.index_id"
    #
    loop_
       _category_examples.detail     
@@ -3304,7 +3304,7 @@ save_nef_peak
 ;
   loop_
 
-      _nef_peak.ordinal
+      _nef_peak.index_id
       _nef_peak.peak_id
       _nef_peak.volume
       _nef_peak.volume_uncertainty
@@ -3329,7 +3329,7 @@ save_nef_peak
       _nef_peak.residue_name_3
       _nef_peak.atom_name_3
 
-  #key: ordinal
+  #key: index_id
 
  1  1 7.3E7 5.1E6 3.3E7 1.1E6  3.2 0.05 119.5 0.5 8.3 0.03 A 19 LEU HBY A 17 GLN N   A 17 GLN H
  2  1 7.3E7 5.1E6 3.3E7 1.1E6  3.2 0.05 119.5 0.5 8.3 0.03 A 20 CYS HBX A 17 GLN N   A 17 GLN H
@@ -3345,7 +3345,7 @@ save_nef_peak
 ;
        "Example 2"
 ;   loop_
-      _nef_peak.ordinal
+      _nef_peak.index_id
       _nef_peak.peak_id
       _nef_peak.volume
       _nef_peak.volume_uncertainty
@@ -3452,12 +3452,12 @@ save_nef_peak
    #
 save_
 #
-save__nef_peak.ordinal
+save__nef_peak.index_id
    #
    
    _item_description.description  "Line number for the peak loop - not preserved when data are read."
    #
-   _item.name            "_nef_peak.ordinal"
+   _item.name            "_nef_peak.index_id"
    _item.category_id     nef_peak
    _item.mandatory_code  yes
    #


### PR DESCRIPTION
New system for specifying elements and isotopes
- Elements with one-letter names ('H', 'C', ...) have the element deduced from the first letter of the name.
- Elements with two-letter names (e.g. Ca, Cd, Zn, ...) must have the element code specified in the _nef_chemical_shift.element column
- Isotopes are normally asumed to be the default form (e.g. 1H for hydrogen, 13C for NMR active carbon, 15N for NMR active nitrogen, etc.). Isotopes that can not be deduced from context (e.g. 2H, different active Cd isotopes) must have their isotope number specified in the _new_chemical_shift.isotope_number column
